### PR TITLE
Hotfix: Handle bucket already existing

### DIFF
--- a/core/initializer/initializer.go
+++ b/core/initializer/initializer.go
@@ -17,7 +17,7 @@ func InitialLoad(textileClient *tc.TextileClient) {
 	}
 
 	if err := textileClient.CreateBucket(defaultPersonalBucketSlug); err != nil {
-		log.Error("Error when creating default bucket. Maybe it already exists", err)
+		panic("Error when creating default bucket. " + err.Error())
 	}
 
 	// TODO: Add other initialization logic

--- a/core/textile/client/client.go
+++ b/core/textile/client/client.go
@@ -160,6 +160,19 @@ func (tc *TextileClient) CreateBucket(bucketSlug string) error {
 	}
 	ctx = common.NewThreadIDContext(ctx, *dbID)
 
+	// return if bucket aready exists
+	// TODO: see if threads.find would be faster
+	bucketList, err := tc.buckets.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, r := range bucketList.Roots {
+		if r.Name == bucketSlug {
+			log.Info("Bucket %s already exists", bucketSlug)
+			return nil
+		}
+	}
+
 	// create bucket
 	log.Debug("Generating bucket")
 	if _, err := tc.buckets.Init(ctx, bucketSlug); err != nil {


### PR DESCRIPTION
In create bucket, we check if the bucket already exists and return no error. Updated initializer to panic if there is still an error but maybe we change that to return an error as well and return that error instead of panicking?