### PR TITLE
Trigger textile Add/Delete on filesystem Create/Remove

### DIFF
--- a/core/sync/fs/fs.go
+++ b/core/sync/fs/fs.go
@@ -1,8 +1,11 @@
 package fs
 
 import (
+	"context"
 	"fmt"
 	"os"
+
+	path2 "github.com/ipfs/interface-go-ipfs-core/path"
 
 	tc "github.com/FleekHQ/space-poc/core/textile/client"
 	"github.com/FleekHQ/space-poc/log"
@@ -11,41 +14,98 @@ import (
 // Implementation to handle events from FS
 type Handler struct {
 	client *tc.TextileClient
+	bucket *tc.TextileBucketRoot
 }
 
 // Creates a New File System Handler // TODO define what is needed as options like push notifications, etc
-func NewHandler(textileClient *tc.TextileClient) *Handler {
+func NewHandler(textileClient *tc.TextileClient, bucketRoot *tc.TextileBucketRoot) *Handler {
 	return &Handler{
 		client: textileClient,
+		bucket: bucketRoot,
 	}
 }
 
-func (h *Handler) OnCreate(path string, fileInfo os.FileInfo) {
+func (h *Handler) OnCreate(ctx context.Context, path string, fileInfo os.FileInfo) {
 	log.Info("Textile Handler: OnCreate", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
+	// TODO: Synchronizer lock check should ensure that no other operation is currently ongoing
+	// with this path or its parent folder
+
+	var result path2.Resolved
+	var newRoot path2.Path
+	var err error
+
+	if fileInfo.IsDir() {
+		result, newRoot, err = h.client.CreateDirectory(ctx, h.bucket.Key, path)
+	} else {
+		fileReader, err := os.Open(path)
+		if err != nil {
+			log.Error("Could not open file for upload", err)
+			return
+		}
+
+		result, newRoot, err = h.client.UploadFile(ctx, h.bucket.Key, path, fileReader)
+	}
+
+	if err != nil {
+		log.Error("Uploading to textile failed", err, fmt.Sprintf("path:%s", path))
+		return
+	}
+	if err = result.IsValid(); err != nil {
+		log.Error("Uploading to textile not valid", err, fmt.Sprintf("path:%s", path))
+		return
+	}
+
+	log.Info(
+		"Successfully uploaded item to textile",
+		fmt.Sprintf("path:%s", path),
+		fmt.Sprintf("itemCid:%s", result.Cid()),
+		fmt.Sprintf("rootCid:%s", newRoot.String()),
+	)
+
+	// TODO: Update synchronizer/store (maybe in a defer function)
 }
 
-func (h *Handler) OnRemove(path string, fileInfo os.FileInfo) {
+func (h *Handler) OnRemove(ctx context.Context, path string, fileInfo os.FileInfo) {
 	log.Info("Textile Handler: OnRemove", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
+	// TODO: Also synchronizer lock check here
+
+	err := h.client.DeleteDirOrFile(ctx, h.bucket.Key, path)
+
+	if err != nil {
+		log.Error("Deleting from textile failed", err, fmt.Sprintf("path:%s", path))
+		return
+	}
+
+	log.Info(
+		"Successfully deleted item from textile",
+		fmt.Sprintf("path:%s", path),
+	)
+	// TODO: Update synchronizer/store (maybe in a defer function)
 }
 
-func (h *Handler) OnWrite(path string, fileInfo os.FileInfo) {
+func (h *Handler) OnWrite(ctx context.Context, path string, fileInfo os.FileInfo) {
 	log.Info("Textile Handler: OnWrite", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
+	h.OnCreate(ctx, path, fileInfo)
 }
 
-func (h *Handler) OnRename(path string, fileInfo os.FileInfo, oldPath string) {
+func (h *Handler) OnRename(ctx context.Context, path string, fileInfo os.FileInfo, oldPath string) {
 	log.Info(
 		"Textile Handler: OnRename",
 		fmt.Sprintf("path:%s", path),
 		fmt.Sprintf("fileInfo:%v", fileInfo),
 		fmt.Sprintf("path:%s", oldPath),
 	)
+	h.OnRemove(ctx, oldPath, fileInfo)
+	h.OnCreate(ctx, path, fileInfo)
 }
 
-func (h *Handler) OnMove(path string, fileInfo os.FileInfo, oldPath string) {
+func (h *Handler) OnMove(ctx context.Context, path string, fileInfo os.FileInfo, oldPath string) {
 	log.Info(
 		"Textile Handler: OnMove",
 		fmt.Sprintf("path:%s", path),
 		fmt.Sprintf("fileInfo:%v", fileInfo),
 		fmt.Sprintf("path:%s", oldPath),
 	)
+	h.OnRemove(ctx, oldPath, fileInfo)
+	h.OnCreate(ctx, path, fileInfo)
 }

--- a/core/sync/sync.go
+++ b/core/sync/sync.go
@@ -18,6 +18,7 @@ type BucketSynchronizer struct {
 	textileClient *tc.TextileClient
 	fh            *fs.Handler
 	th            *textile.Handler
+	bucketRoot    *tc.TextileBucketRoot
 	// textileWatcher
 	// th textileHandler
 	// NOTE: not sure we need the complete grpc server here, but that could change
@@ -25,14 +26,20 @@ type BucketSynchronizer struct {
 }
 
 // Creates a new BucketSynchronizer instance
-func New(folderWatcher *watcher.FolderWatcher, textileClient *tc.TextileClient, notify func(event events.FileEvent)) *BucketSynchronizer {
-	fh := fs.NewHandler(textileClient)
+func New(
+	folderWatcher *watcher.FolderWatcher,
+	textileClient *tc.TextileClient,
+	bucketRoot *tc.TextileBucketRoot,
+	notify func(event events.FileEvent),
+) *BucketSynchronizer {
+	fh := fs.NewHandler(textileClient, bucketRoot)
 	th := textile.NewHandler()
 	return &BucketSynchronizer{
 		folderWatcher: folderWatcher,
 		textileClient: textileClient,
 		fh:            fh,
 		th:            th,
+		bucketRoot:    bucketRoot,
 		notify:        notify,
 		// textileWatcher: textileWatcher,
 	}
@@ -53,11 +60,6 @@ func (bs *BucketSynchronizer) Start(ctx context.Context) error {
 		log.Fatal(err)
 		return err
 	}
-
-	// if err := bs.textileWatcher.Watch(ctx, textileBucketEventHandler); err != nil {
-	// 	log.Fatal(err)
-	// 	return err
-	// }
 
 	return nil
 }

--- a/core/watcher/handler.go
+++ b/core/watcher/handler.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -9,29 +10,46 @@ import (
 
 // EventHandler
 type EventHandler interface {
-	OnCreate(path string, fileInfo os.FileInfo)
-	OnRemove(path string, fileInfo os.FileInfo)
-	OnWrite(path string, fileInfo os.FileInfo)
-	OnRename(path string, fileInfo os.FileInfo, oldPath string)
-	OnMove(path string, fileInfo os.FileInfo, oldPath string)
+	OnCreate(ctx context.Context, path string, fileInfo os.FileInfo)
+	OnRemove(ctx context.Context, path string, fileInfo os.FileInfo)
+	OnWrite(ctx context.Context, path string, fileInfo os.FileInfo)
+	OnRename(ctx context.Context, path string, fileInfo os.FileInfo, oldPath string)
+	OnMove(ctx context.Context, path string, fileInfo os.FileInfo, oldPath string)
 }
 
 // Implements EventHandler and defaults to logging actions performed
 type defaultWatcherHandler struct{}
 
-func (h *defaultWatcherHandler) OnCreate(path string, fileInfo os.FileInfo) {
+func (h *defaultWatcherHandler) OnCreate(
+	ctx context.Context,
+	path string,
+	fileInfo os.FileInfo,
+) {
 	log.Info("Default Watcher Handler: OnCreate", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
 }
 
-func (h *defaultWatcherHandler) OnRemove(path string, fileInfo os.FileInfo) {
+func (h *defaultWatcherHandler) OnRemove(
+	ctx context.Context,
+	path string,
+	fileInfo os.FileInfo,
+) {
 	log.Info("Default Watcher Handler: OnRemove", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
 }
 
-func (h *defaultWatcherHandler) OnWrite(path string, fileInfo os.FileInfo) {
+func (h *defaultWatcherHandler) OnWrite(
+	ctx context.Context,
+	path string,
+	fileInfo os.FileInfo,
+) {
 	log.Info("Default Watcher Handler: OnWrite", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
 }
 
-func (h *defaultWatcherHandler) OnRename(path string, fileInfo os.FileInfo, oldPath string) {
+func (h *defaultWatcherHandler) OnRename(
+	ctx context.Context,
+	path string,
+	fileInfo os.FileInfo,
+	oldPath string,
+) {
 	log.Info(
 		"Default Watcher Handler: OnRename",
 		fmt.Sprintf("path:%s", path),
@@ -40,7 +58,12 @@ func (h *defaultWatcherHandler) OnRename(path string, fileInfo os.FileInfo, oldP
 	)
 }
 
-func (h *defaultWatcherHandler) OnMove(path string, fileInfo os.FileInfo, oldPath string) {
+func (h *defaultWatcherHandler) OnMove(
+	ctx context.Context,
+	path string,
+	fileInfo os.FileInfo,
+	oldPath string,
+) {
 	log.Info(
 		"Default Watcher Handler: OnMove",
 		fmt.Sprintf("path:%s", path),

--- a/core/watcher/watcher.go
+++ b/core/watcher/watcher.go
@@ -96,9 +96,9 @@ func (fw *FolderWatcher) Watch(ctx context.Context) error {
 			case event, ok := <-fw.w.Event:
 				if ok {
 					if len(fw.handlers) == 0 {
-						fw.publishEventToHandler(&defaultWatcherHandler{}, event)
+						fw.publishEventToHandler(ctx, &defaultWatcherHandler{}, event)
 					} else {
-						fw.publishEvent(event)
+						fw.publishEvent(ctx, event)
 					}
 				}
 			case err, ok := <-fw.w.Error:
@@ -130,27 +130,31 @@ func (fw *FolderWatcher) setToStarted() {
 	fw.started = true
 }
 
-func (fw *FolderWatcher) publishEvent(event watcher.Event) {
+func (fw *FolderWatcher) publishEvent(ctx context.Context, event watcher.Event) {
 	fw.publishLock.RLock()
 	defer fw.publishLock.RUnlock()
 
 	for _, handler := range fw.handlers {
-		fw.publishEventToHandler(handler, event)
+		fw.publishEventToHandler(ctx, handler, event)
 	}
 }
 
-func (fw *FolderWatcher) publishEventToHandler(handler EventHandler, event watcher.Event) {
+func (fw *FolderWatcher) publishEventToHandler(
+	ctx context.Context,
+	handler EventHandler,
+	event watcher.Event,
+) {
 	switch event.Op {
 	case watcher.Create:
-		handler.OnCreate(event.Path, event.FileInfo)
+		handler.OnCreate(ctx, event.Path, event.FileInfo)
 	case watcher.Remove:
-		handler.OnRemove(event.Path, event.FileInfo)
+		handler.OnRemove(ctx, event.Path, event.FileInfo)
 	case watcher.Write:
-		handler.OnWrite(event.Path, event.FileInfo)
+		handler.OnWrite(ctx, event.Path, event.FileInfo)
 	case watcher.Rename:
-		handler.OnRename(event.Path, event.FileInfo, event.OldPath)
+		handler.OnRename(ctx, event.Path, event.FileInfo, event.OldPath)
 	case watcher.Move:
-		handler.OnMove(event.Path, event.FileInfo, event.OldPath)
+		handler.OnMove(ctx, event.Path, event.FileInfo, event.OldPath)
 	}
 }
 

--- a/core/watcher/watcher_test.go
+++ b/core/watcher/watcher_test.go
@@ -16,24 +16,24 @@ type handlerMock struct {
 	mock.Mock
 }
 
-func (h *handlerMock) OnCreate(path string, fileInfo os.FileInfo) {
-	h.Called(path, fileInfo)
+func (h *handlerMock) OnCreate(ctx context.Context, path string, fileInfo os.FileInfo) {
+	h.Called(ctx, path, fileInfo)
 }
 
-func (h *handlerMock) OnRemove(path string, fileInfo os.FileInfo) {
-	h.Called(path, fileInfo)
+func (h *handlerMock) OnRemove(ctx context.Context, path string, fileInfo os.FileInfo) {
+	h.Called(ctx, path, fileInfo)
 }
 
-func (h *handlerMock) OnWrite(path string, fileInfo os.FileInfo) {
-	h.Called(path, fileInfo)
+func (h *handlerMock) OnWrite(ctx context.Context, path string, fileInfo os.FileInfo) {
+	h.Called(ctx, path, fileInfo)
 }
 
-func (h *handlerMock) OnRename(path string, fileInfo os.FileInfo, oldPath string) {
-	h.Called(path, fileInfo, oldPath)
+func (h *handlerMock) OnRename(ctx context.Context, path string, fileInfo os.FileInfo, oldPath string) {
+	h.Called(ctx, path, fileInfo, oldPath)
 }
 
-func (h *handlerMock) OnMove(path string, fileInfo os.FileInfo, oldPath string) {
-	h.Called(path, fileInfo, oldPath)
+func (h *handlerMock) OnMove(ctx context.Context, path string, fileInfo os.FileInfo, oldPath string) {
+	h.Called(ctx, path, fileInfo, oldPath)
 }
 
 func isTriggeredEvent(info os.FileInfo) bool {


### PR DESCRIPTION
**CHANGELOG**
- Implement FileWatcher.EventHandler for BucketSync and setup the OnCreate and OnRemove events to trigger corresponding actions on the TextileClient.
- Refactored TextileClient and add `CreateDefaultBucket()` to make it easier to access the default bucket
- Some refactoring to long running functions/operations to accept context as input. Also deleted context from the TextileClient struct as it is considered an antipattern to store context on a struct.

NOTE: This PR assumes no synchronization logic, so contention can still happen on concurrent uploads within the same directory