### PR TITLE
Fix: use BucketContext on textile crud operations

### DIFF
--- a/core/sync/fs/fs.go
+++ b/core/sync/fs/fs.go
@@ -26,7 +26,10 @@ func NewHandler(textileClient *tc.TextileClient, bucketRoot *tc.TextileBucketRoo
 }
 
 func (h *Handler) OnCreate(ctx context.Context, path string, fileInfo os.FileInfo) {
-	log.Info("FS Handler: OnCreate", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
+	log.Info(
+		"FS Handler: OnCreate", fmt.Sprintf("path:%s", path),
+		fmt.Sprintf("fileName:%s", fileInfo.Name()),
+	)
 	// TODO: Synchronizer lock check should ensure that no other operation is currently ongoing
 	// with this path or its parent folder
 
@@ -66,7 +69,7 @@ func (h *Handler) OnCreate(ctx context.Context, path string, fileInfo os.FileInf
 }
 
 func (h *Handler) OnRemove(ctx context.Context, path string, fileInfo os.FileInfo) {
-	log.Info("FS Handler: OnRemove", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
+	log.Info("FS Handler: OnRemove", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileName:%s", fileInfo.Name()))
 	// TODO: Also synchronizer lock check here
 
 	err := h.client.DeleteDirOrFile(ctx, h.bucket.Key, path)
@@ -83,8 +86,9 @@ func (h *Handler) OnRemove(ctx context.Context, path string, fileInfo os.FileInf
 	// TODO: Update synchronizer/store (maybe in a defer function)
 }
 
+// OnWrite is invoked when a new file is created or files content is updated
 func (h *Handler) OnWrite(ctx context.Context, path string, fileInfo os.FileInfo) {
-	log.Info("FS Handler: OnWrite", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileInfo:%v", fileInfo))
+	log.Info("FS Handler: OnWrite", fmt.Sprintf("path:%s", path), fmt.Sprintf("fileName:%s", fileInfo.Name()))
 	h.OnCreate(ctx, path, fileInfo)
 }
 
@@ -92,7 +96,7 @@ func (h *Handler) OnRename(ctx context.Context, path string, fileInfo os.FileInf
 	log.Info(
 		"Watcher Handler: OnRename",
 		fmt.Sprintf("path:%s", path),
-		fmt.Sprintf("fileInfo:%v", fileInfo),
+		fmt.Sprintf("fileName:%s", fileInfo.Name()),
 		fmt.Sprintf("path:%s", oldPath),
 	)
 	h.OnRemove(ctx, oldPath, fileInfo)
@@ -103,7 +107,7 @@ func (h *Handler) OnMove(ctx context.Context, path string, fileInfo os.FileInfo,
 	log.Info(
 		"Watcher Handler: OnMove",
 		fmt.Sprintf("path:%s", path),
-		fmt.Sprintf("fileInfo:%v", fileInfo),
+		fmt.Sprintf("fileName:%s", fileInfo.Name()),
 		fmt.Sprintf("path:%s", oldPath),
 	)
 	h.OnRemove(ctx, oldPath, fileInfo)

--- a/core/textile/client/client.go
+++ b/core/textile/client/client.go
@@ -1,16 +1,11 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
-	"io"
 	"os"
-	"strings"
 	"time"
-
-	"github.com/ipfs/interface-go-ipfs-core/path"
 
 	buckets_pb "github.com/textileio/textile/api/buckets/pb"
 
@@ -328,49 +323,4 @@ func (tc *TextileClient) StartAndBootstrap() error {
 
 	log.Debug("Textile Client initialized successfully")
 	return nil
-}
-
-// UploadFile uploads a file to path on textile
-// path should include the file name as the last path segment
-// also nested path not existing yet would be created automatically
-func (tc *TextileClient) UploadFile(
-	ctx context.Context,
-	bucketKey string,
-	path string,
-	reader io.Reader,
-) (result path.Resolved, root path.Path, err error) {
-	return tc.buckets.PushPath(ctx, bucketKey, path, reader)
-}
-
-// CreateDirectory creates an empty directory
-// Because textile doesn't support empty directory an empty .keep file is created
-// in the directory
-func (tc *TextileClient) CreateDirectory(
-	ctx context.Context,
-	bucketKey string,
-	path string,
-) (result path.Resolved, root path.Path, err error) {
-	// append .keep file to the end of the directory
-	emptyDirPath := strings.TrimRight(path, "/") + "/" + keepFileName
-	return tc.buckets.PushPath(ctx, bucketKey, emptyDirPath, &bytes.Buffer{})
-}
-
-// ListDirectory returns a list of items in a particular directory
-func (tc *TextileClient) ListDirectory(
-	ctx context.Context,
-	bucketKey string,
-	path string,
-) (*TextileDirEntries, error) {
-	result, err := tc.buckets.ListPath(ctx, bucketKey, path)
-
-	return (*TextileDirEntries)(result), err
-}
-
-// DeleteDirOrFile will delete file or directory at path
-func (tc *TextileClient) DeleteDirOrFile(
-	ctx context.Context,
-	bucketKey string,
-	path string,
-) error {
-	return tc.buckets.RemovePath(ctx, bucketKey, path)
 }

--- a/core/textile/client/crud.go
+++ b/core/textile/client/crud.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+
+	"github.com/ipfs/interface-go-ipfs-core/path"
+)
+
+// UploadFile uploads a file to path on textile
+// path should include the file name as the last path segment
+// also nested path not existing yet would be created automatically
+func (tc *TextileClient) UploadFile(
+	ctx context.Context,
+	bucketKey string,
+	path string,
+	reader io.Reader,
+) (result path.Resolved, root path.Path, err error) {
+	ctx, _, err = tc.GetBucketContext(defaultPersonalBucketSlug)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tc.buckets.PushPath(ctx, bucketKey, path, reader)
+}
+
+// CreateDirectory creates an empty directory
+// Because textile doesn't support empty directory an empty .keep file is created
+// in the directory
+func (tc *TextileClient) CreateDirectory(
+	ctx context.Context,
+	bucketKey string,
+	path string,
+) (result path.Resolved, root path.Path, err error) {
+	ctx, _, err = tc.GetBucketContext(defaultPersonalBucketSlug)
+	if err != nil {
+		return nil, nil, err
+	}
+	// append .keep file to the end of the directory
+	emptyDirPath := strings.TrimRight(path, "/") + "/" + keepFileName
+	return tc.buckets.PushPath(ctx, bucketKey, emptyDirPath, &bytes.Buffer{})
+}
+
+// ListDirectory returns a list of items in a particular directory
+func (tc *TextileClient) ListDirectory(
+	ctx context.Context,
+	bucketKey string,
+	path string,
+) (*TextileDirEntries, error) {
+	ctx, _, err := tc.GetBucketContext(defaultPersonalBucketSlug)
+	if err != nil {
+		return nil, err
+	}
+	result, err := tc.buckets.ListPath(ctx, bucketKey, path)
+
+	return (*TextileDirEntries)(result), err
+}
+
+// DeleteDirOrFile will delete file or directory at path
+func (tc *TextileClient) DeleteDirOrFile(
+	ctx context.Context,
+	bucketKey string,
+	path string,
+) error {
+	ctx, _, err := tc.GetBucketContext(defaultPersonalBucketSlug)
+	if err != nil {
+		return err
+	}
+	return tc.buckets.RemovePath(ctx, bucketKey, path)
+}


### PR DESCRIPTION
With this, CRUD operations through the TextileClient are now successful.