### PR TITLE
Exclude fuse from windows build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,7 @@ jobs:
       matrix:
         #go-version: [1.13.x, 1.14.x]
         go-version: [1.14.x]
-        #platform: [ubuntu-latest, macos-latest, windows-latest]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go

--- a/core/libfuse/directory.go
+++ b/core/libfuse/directory.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 package libfuse
 
 import (

--- a/core/libfuse/files.go
+++ b/core/libfuse/files.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 package libfuse
 
 import (

--- a/core/libfuse/vfs.go
+++ b/core/libfuse/vfs.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 package libfuse
 
 import (

--- a/core/space/fuse/controller.go
+++ b/core/space/fuse/controller.go
@@ -9,16 +9,15 @@ import (
 	"github.com/FleekHQ/space-daemon/core/spacefs"
 
 	"github.com/FleekHQ/space-daemon/config"
-	"github.com/FleekHQ/space-daemon/core/libfuse"
 	"github.com/FleekHQ/space-daemon/core/store"
 	"github.com/FleekHQ/space-daemon/log"
 )
 
-// Controller is the space domain controller for managing the libfuse VFS.
+// Controller is the space domain controller for managing the VFS.
 // It is used by the grpc server and app/daemon generally
 type Controller struct {
 	cfg       config.Config
-	vfs       *libfuse.VFS
+	vfs       VFS
 	store     store.Store
 	isServed  bool
 	mountLock sync.RWMutex
@@ -33,7 +32,7 @@ func NewController(
 	store store.Store,
 	sfs *spacefs.SpaceFS,
 ) *Controller {
-	vfs := libfuse.NewVFileSystem(ctx, sfs)
+	vfs := initVFS(ctx, sfs)
 
 	return &Controller{
 		cfg:       cfg,
@@ -44,7 +43,7 @@ func NewController(
 	}
 }
 
-// ShouldMount check the store and config to determine if the libfuse drive was previously mounted
+// ShouldMount check the store and config to determine if the VFS drive was previously mounted
 func (s *Controller) ShouldMount() bool {
 	if s.cfg.GetString(config.MountFuseDrive, "false") == "true" {
 		return true

--- a/core/space/fuse/fs.go
+++ b/core/space/fuse/fs.go
@@ -1,0 +1,12 @@
+package fuse
+
+// VFS represents the handler for virtually mounted drives.
+// it is implemented using FUSE for linux and macOS
+// and will use dokany for windows
+type VFS interface {
+	Mount(mountPath, fsName string) error
+	IsMounted() bool
+	// Serve should be a blocking call and return only on unmount or shutdown
+	Serve() error
+	Unmount() error
+}

--- a/core/space/fuse/mount.go
+++ b/core/space/fuse/mount.go
@@ -1,9 +1,16 @@
+//+build !windows
+
 package fuse
 
 import (
+	"context"
 	"fmt"
 	"os"
 	s "strings"
+
+	"github.com/FleekHQ/space-daemon/core/libfuse"
+
+	"github.com/FleekHQ/space-daemon/core/spacefs"
 
 	"github.com/FleekHQ/space-daemon/config"
 	"github.com/mitchellh/go-homedir"
@@ -37,4 +44,8 @@ func getMountPath(cfg config.Config) (string, error) {
 	}
 
 	return mountPath, nil
+}
+
+func initVFS(ctx context.Context, sfs spacefs.FSOps) VFS {
+	return libfuse.NewVFileSystem(ctx, sfs)
 }

--- a/core/space/fuse/mount_windows.go
+++ b/core/space/fuse/mount_windows.go
@@ -1,0 +1,42 @@
+package fuse
+
+import (
+	"context"
+	"errors"
+
+	"github.com/FleekHQ/space-daemon/config"
+	"github.com/FleekHQ/space-daemon/core/spacefs"
+)
+
+var errNotImplemented = errors.New("fuse not implemented for windows")
+
+func pathExists(path string) bool {
+	return false
+}
+
+func getMountPath(cfg config.Config) (string, error) {
+	return "", errNotImplemented
+}
+
+func initVFS(ctx context.Context, sfs spacefs.FSOps) VFS {
+	return &dummyVFS{}
+}
+
+// dummyVFS acts a placeholder vfs for windows pending the actual implementation
+type dummyVFS struct{}
+
+func (d dummyVFS) Mount(mountPath, fsName string) error {
+	return errNotImplemented
+}
+
+func (d dummyVFS) IsMounted() bool {
+	return false
+}
+
+func (d dummyVFS) Serve() error {
+	return errNotImplemented
+}
+
+func (d dummyVFS) Unmount() error {
+	return errNotImplemented
+}

--- a/core/watcher/blacklist.go
+++ b/core/watcher/blacklist.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 package watcher
 
 import (


### PR DESCRIPTION
**CHANGELOG**
- Extract VFS into an interface
- Isolate initializing libfuse.NewVFSSystem() to only non-windows builds
- Enaables windows-latest on ci's test matrix platform