### PR TITLE
Fix: Truncate Badger Data logs on windows

### DIFF
--- a/core/store/store.go
+++ b/core/store/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	s "strings"
 
 	"github.com/FleekHQ/space-daemon/core"
@@ -85,7 +86,9 @@ func (store *store) Open() error {
 	}
 
 	db, err := badger.Open(
-		badger.DefaultOptions(rootDir).WithEventLogging(false),
+		badger.DefaultOptions(rootDir).
+			WithEventLogging(false).
+			WithTruncate(runtime.GOOS == "windows"),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes the issue in the image below when running daemon on windows:

![image (2)](https://user-images.githubusercontent.com/3120013/87235568-25ed9900-c3d5-11ea-9350-596cb381b064.png)
