### PR TITLE
Hotfix: misc timing issues

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -86,11 +86,9 @@ func (a *App) Start(ctx context.Context) error {
 
 	// setup local buckets
 	buckd := textile.NewBuckd(a.cfg)
-	err = buckd.Start(ctx)
-	if err != nil {
-		return err
-	}
-	a.Run("BucketDaemon", buckd)
+	a.RunAsync("BucketDaemon", buckd, func() error {
+		return buckd.Start(ctx)
+	})
 
 	// setup textile client
 	textileClient := textile.NewClient(appStore)

--- a/core/sync/sync.go
+++ b/core/sync/sync.go
@@ -90,6 +90,7 @@ func New(
 
 // Starts the folder watcher and the textile watcher.
 func (bs *bucketSynchronizer) Start(ctx context.Context) error {
+	// Disabling this temporarily due to errors
 	//buckets, err := bs.textileClient.ListBuckets(ctx)
 	// if err != nil {
 	// 	return err
@@ -113,6 +114,7 @@ func (bs *bucketSynchronizer) Start(ctx context.Context) error {
 	// handlers := make([]textile.EventHandler, 0)
 	// handlers = append(handlers, bs.th)
 
+	// Disabling this temporarily due to errors
 	//for range buckets {
 	// bs.textileThreadListeners = append(bs.textileThreadListeners, textile.NewListener(bs.textileClient, bucket.Slug(), handlers))
 	//}

--- a/core/sync/sync.go
+++ b/core/sync/sync.go
@@ -90,10 +90,10 @@ func New(
 
 // Starts the folder watcher and the textile watcher.
 func (bs *bucketSynchronizer) Start(ctx context.Context) error {
-	buckets, err := bs.textileClient.ListBuckets(ctx)
-	if err != nil {
-		return err
-	}
+	//buckets, err := bs.textileClient.ListBuckets(ctx)
+	// if err != nil {
+	// 	return err
+	// }
 
 	if bs.notifier == nil {
 		log.Printf("using default notifier to start bucket sync")
@@ -113,9 +113,9 @@ func (bs *bucketSynchronizer) Start(ctx context.Context) error {
 	// handlers := make([]textile.EventHandler, 0)
 	// handlers = append(handlers, bs.th)
 
-	for range buckets {
-		// bs.textileThreadListeners = append(bs.textileThreadListeners, textile.NewListener(bs.textileClient, bucket.Slug(), handlers))
-	}
+	//for range buckets {
+	// bs.textileThreadListeners = append(bs.textileThreadListeners, textile.NewListener(bs.textileClient, bucket.Slug(), handlers))
+	//}
 
 	bs.folderWatcher.RegisterHandler(bs.fh)
 

--- a/core/textile/buckd.go
+++ b/core/textile/buckd.go
@@ -25,13 +25,13 @@ var MinThreadsConn int
 type TextileBuckd struct {
 	textile   *core.Textile
 	IsRunning bool
-	ready     chan bool
+	Ready     chan bool
 	cfg       config.Config
 }
 
 func NewBuckd(cfg config.Config) *TextileBuckd {
 	return &TextileBuckd{
-		ready: make(chan bool),
+		Ready: make(chan bool),
 		cfg:   cfg,
 	}
 }
@@ -105,13 +105,18 @@ func (tb *TextileBuckd) Start(ctx context.Context) error {
 	log.Info("Welcome to bucket", fmt.Sprintf("peerID:%s", textile.HostID().String()))
 	tb.textile = textile
 	tb.IsRunning = true
+	tb.Ready <- true
 	return nil
+}
+
+func (tb *TextileBuckd) WaitForReady() chan bool {
+	return tb.Ready
 }
 
 func (tb *TextileBuckd) Stop() error {
 	tb.IsRunning = false
 	tb.textile.Close()
-	close(tb.ready)
+	close(tb.Ready)
 	// TODO: what else
 	return nil
 }

--- a/core/textile/buckd.go
+++ b/core/textile/buckd.go
@@ -103,6 +103,10 @@ func (tb *TextileBuckd) Start(ctx context.Context) error {
 	textile.Bootstrap()
 
 	log.Info("Welcome to bucket", fmt.Sprintf("peerID:%s", textile.HostID().String()))
+
+	log.Info("Sleeping for 5s to wait for ports to listen ...")
+	time.Sleep(5 * time.Second)
+
 	tb.textile = textile
 	tb.IsRunning = true
 	tb.Ready <- true

--- a/core/textile/buckd.go
+++ b/core/textile/buckd.go
@@ -3,7 +3,6 @@ package textile
 import (
 	"context"
 	"fmt"
-	"net"
 	"os/user"
 	"time"
 
@@ -105,17 +104,8 @@ func (tb *TextileBuckd) Start(ctx context.Context) error {
 
 	log.Info("Welcome to bucket", fmt.Sprintf("peerID:%s", textile.HostID().String()))
 
-	// wait for the port to be listening to consider it done
-	log.Info("Waiting for 127.0.0.1 3006 to listen")
-	for {
-		conn, _ := net.Dial("tcp", net.JoinHostPort("127.0.0.1", "3006"))
-		if conn != nil {
-			log.Info("Test connection made")
-			conn.Close()
-			break
-		}
-		log.Info("Test connection failed")
-	}
+	log.Info("Sleeping for 5s to wait for buckd grpc ports to listen ...")
+	time.Sleep(5 * time.Second)
 
 	tb.textile = textile
 	tb.IsRunning = true

--- a/core/textile/buckd.go
+++ b/core/textile/buckd.go
@@ -106,8 +106,9 @@ func (tb *TextileBuckd) Start(ctx context.Context) error {
 	log.Info("Welcome to bucket", fmt.Sprintf("peerID:%s", textile.HostID().String()))
 
 	// wait for the port to be listening to consider it done
+	log.Info("Waiting for 127.0.0.1 3006 to listen")
 	for {
-		conn, _ := net.Dial("tcp", net.JoinHostPort("localhost", "3006"))
+		conn, _ := net.Dial("tcp", net.JoinHostPort("127.0.0.1", "3006"))
 		if conn != nil {
 			conn.Close()
 			break

--- a/core/textile/buckd.go
+++ b/core/textile/buckd.go
@@ -121,7 +121,6 @@ func (tb *TextileBuckd) Stop() error {
 	tb.IsRunning = false
 	tb.textile.Close()
 	close(tb.Ready)
-	// TODO: what else
 	return nil
 }
 

--- a/core/textile/buckd.go
+++ b/core/textile/buckd.go
@@ -110,9 +110,11 @@ func (tb *TextileBuckd) Start(ctx context.Context) error {
 	for {
 		conn, _ := net.Dial("tcp", net.JoinHostPort("127.0.0.1", "3006"))
 		if conn != nil {
+			log.Info("Test connection made")
 			conn.Close()
 			break
 		}
+		log.Info("Test connection failed")
 	}
 
 	tb.textile = textile

--- a/core/textile/buckd.go
+++ b/core/textile/buckd.go
@@ -3,6 +3,7 @@ package textile
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/user"
 	"time"
 
@@ -104,8 +105,14 @@ func (tb *TextileBuckd) Start(ctx context.Context) error {
 
 	log.Info("Welcome to bucket", fmt.Sprintf("peerID:%s", textile.HostID().String()))
 
-	log.Info("Sleeping for 5s to wait for ports to listen ...")
-	time.Sleep(5 * time.Second)
+	// wait for the port to be listening to consider it done
+	for {
+		conn, _ := net.Dial("tcp", net.JoinHostPort("localhost", "3006"))
+		if conn != nil {
+			conn.Close()
+			break
+		}
+	}
 
 	tb.textile = textile
 	tb.IsRunning = true

--- a/core/textile/bucket_factory.go
+++ b/core/textile/bucket_factory.go
@@ -51,6 +51,7 @@ func (tc *textileClient) GetBucketContext(ctx context.Context, bucketSlug string
 
 	log.Debug("GetBucketContext: Fetching thread id from meta store")
 	bucketSchema, notFoundErr := tc.findBucketInCollection(ctx, bucketSlug)
+
 	if notFoundErr == nil { // This means the bucket was already present in the schema
 		dbID, err := parseDbIDFromString(bucketSchema.DbID)
 		if err != nil {
@@ -59,6 +60,10 @@ func (tc *textileClient) GetBucketContext(ctx context.Context, bucketSlug string
 		}
 		log.Debug("GetBucketContext: Got dbID from collection: " + dbID.String())
 		ctx, err = tc.getThreadContext(ctx, bucketSlug, *dbID)
+
+		if err != nil {
+			return nil, nil, err
+		}
 		return ctx, dbID, err
 	}
 
@@ -126,6 +131,10 @@ func (tc *textileClient) CreateBucket(ctx context.Context, bucketSlug string) (B
 
 	if b, _ := tc.GetBucket(ctx, bucketSlug); b != nil {
 		return b, nil
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	ctx, dbID, err := tc.GetBucketContext(ctx, bucketSlug)

--- a/core/textile/bucket_factory.go
+++ b/core/textile/bucket_factory.go
@@ -107,6 +107,10 @@ func (tc *textileClient) getBucketRootFromSlug(ctx context.Context, slug string)
 
 	bucketListReply, err := tc.bucketsClient.List(ctx)
 
+	if err != nil {
+		return nil, nil, err
+	}
+
 	for _, root := range bucketListReply.Roots {
 		if root.Name == slug {
 			return ctx, root, nil

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -174,9 +174,6 @@ func (tc *textileClient) Start(ctx context.Context, cfg config.Config) error {
 		return err
 	}
 
-	log.Info("Sleeping for 30 ...")
-	time.Sleep(30 * time.Second)
-
 	log.Debug("Listing buckets...")
 	buckets, err := tc.ListBuckets(ctx)
 	if err != nil {

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -117,7 +117,7 @@ func (tc *textileClient) start(ctx context.Context, cfg config.Config) error {
 	var netc *nc.Client
 
 	// by default it goes to local threads now
-	host := "127.0.0.1:3006"
+	host := "localhost:3006"
 
 	log.Debug("Creating buckets client in " + host)
 	if b, err := bucketsClient.NewClient(host, opts...); err != nil {

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -184,7 +184,6 @@ func (tc *textileClient) Start(ctx context.Context, cfg config.Config) error {
 	// Create default bucket if it doesnt exist
 	defaultBucketExists := false
 	for _, b := range buckets {
-		log.Info("looping through bucket: " + b.Slug())
 		if b.Slug() == defaultPersonalBucketSlug {
 			defaultBucketExists = true
 		}

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -174,6 +174,9 @@ func (tc *textileClient) Start(ctx context.Context, cfg config.Config) error {
 		return err
 	}
 
+	log.Info("Sleeping for 30 ...")
+	time.Sleep(30 * time.Second)
+
 	log.Debug("Listing buckets...")
 	buckets, err := tc.ListBuckets(ctx)
 	if err != nil {

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -187,6 +187,7 @@ func (tc *textileClient) Start(ctx context.Context, cfg config.Config) error {
 	// Create default bucket if it doesnt exist
 	defaultBucketExists := false
 	for _, b := range buckets {
+		log.Info("looping through bucket: " + b.Slug())
 		if b.Slug() == defaultPersonalBucketSlug {
 			defaultBucketExists = true
 		}

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -117,7 +117,7 @@ func (tc *textileClient) start(ctx context.Context, cfg config.Config) error {
 	var netc *nc.Client
 
 	// by default it goes to local threads now
-	host := "localhost:3006"
+	host := "127.0.0.1:3006"
 
 	log.Debug("Creating buckets client in " + host)
 	if b, err := bucketsClient.NewClient(host, opts...); err != nil {

--- a/core/textile/collections.go
+++ b/core/textile/collections.go
@@ -79,6 +79,11 @@ func (tc *textileClient) findBucketInCollection(ctx context.Context, bucketSlug 
 	}
 
 	rawBuckets, err := tc.threads.Find(metaCtx, *dbID, bucketCollectionName, db.Where("slug").Eq(bucketSlug).UseIndex("slug"), &BucketSchema{})
+
+	if err != nil {
+		return nil, err
+	}
+
 	if rawBuckets == nil {
 		return nil, errBucketNotFound
 	}


### PR DESCRIPTION
This should fix some timing related issues that are being seen on some machines (I think more so on smaller ones). It's not final because the right way to do it is to either get a channel from Textile or poll the port to see if its listening yet, but for now doing a `sleep` as a temp fix so hackathon users aren't blocked.

### Change Log
* Make `buckd` wait for ready signal before moving on the next init
* Disable listing buckets in the syncer (this is also causing issues so disabling it until we resolve it - assumed this was okay because the listener was already partly commented out)
* Check for errors in a few places we should have been that were swallowing up errors
* Use `localhost` instead of `127.0.0.1` for bucket client to avoid wierd ipv6/name resolution errors (I think)

### TODO
* If Textile doesn't have a channel or something we can use, poll for port instead of using a sleep
* Fix issue with syncer 