### PR TITLE
Hotfix: Error on startup due to hub context issue

### DIFF
--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -69,14 +69,11 @@ func (tc *textileClient) getHubCtx(ctx context.Context) (context.Context, error)
 	log.Debug("Authenticating with Textile Hub")
 
 	// TODO: Use hub.GetHubToken instead
-	tokStr, err := hub.GetHubTokenUsingTextileKeys(ctx, tc.store, tc.kc, tc.ht)
+	ctx, err := hub.GetHubTokenUsingTextileKeys(ctx, tc.store, tc.kc, tc.ht)
 	if err != nil {
 		return nil, err
 	}
 
-	tok := thread.Token(tokStr)
-
-	ctx = thread.NewTokenContext(ctx, tok)
 	return ctx, nil
 }
 

--- a/core/textile/hub/hub_auth.go
+++ b/core/textile/hub/hub_auth.go
@@ -191,7 +191,7 @@ func GetHubTokenUsingTextileKeys(ctx context.Context, st store.Store, kc keychai
 		}
 	}
 
-	newtok := thread.Token(tokStr)
-	ctx = thread.NewTokenContext(ctx, newtok)
+	tok := thread.Token(tokStr)
+	ctx = thread.NewTokenContext(ctx, tok)
 	return ctx, nil
 }

--- a/core/textile/hub/hub_auth.go
+++ b/core/textile/hub/hub_auth.go
@@ -155,7 +155,6 @@ func GetHubTokenUsingTextileKeys(ctx context.Context, st store.Store, kc keychai
 
 	// prebuild context, needs to happen
 	// whether token is saved or not
-	log.Debug("No hub token in store")
 	key := os.Getenv("TXL_USER_KEY")
 	secret := os.Getenv("TXL_USER_SECRET")
 

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,7 @@ github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGt
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -514,6 +515,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.14.6 h1:8ERzHx8aj1Sc47mu9n/AksaKCSWrMchFtkdrS4BIj5o=
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
+github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gxed/go-shellwords v1.0.3/go.mod h1:N7paucT91ByIjmVJHhvoarjoQnmsi3Jd3vH7VqgtMxQ=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=


### PR DESCRIPTION
Refactored temporary hub context helper to return context instead of token since it requires the API sig context embedded into it as well.