### PR TITLE
Feature:  Bucket Level Encryption

### DIFF
--- a/core/textile/bucket/bucket.go
+++ b/core/textile/bucket/bucket.go
@@ -47,7 +47,11 @@ func (b *Bucket) Slug() string {
 
 type getBucketContextFn func(context.Context, string) (context.Context, *thread.ID, error)
 
-func New(root *bucketsproto.Root, getBucketContext getBucketContextFn, bucketsClient BucketsClient) *Bucket {
+func New(
+	root *bucketsproto.Root,
+	getBucketContext getBucketContextFn,
+	bucketsClient BucketsClient,
+) *Bucket {
 	return &Bucket{
 		root:             root,
 		bucketsClient:    bucketsClient,

--- a/core/textile/bucket/bucket_dir.go
+++ b/core/textile/bucket/bucket_dir.go
@@ -45,6 +45,7 @@ func (b *Bucket) CreateDirectory(ctx context.Context, path string) (result path.
 	if err != nil {
 		return nil, nil, err
 	}
+
 	// append .keep file to the end of the directory
 	emptyDirPath := strings.TrimRight(path, "/") + "/" + keepFileName
 	return b.bucketsClient.PushPath(ctx, b.Key(), emptyDirPath, &bytes.Buffer{})
@@ -60,6 +61,10 @@ func (b *Bucket) ListDirectory(ctx context.Context, path string) (*DirEntries, e
 	}
 
 	result, err := b.bucketsClient.ListPath(ctx, b.Key(), path)
+	if err != nil {
+		return nil, err
+	}
+
 	return (*DirEntries)(result), err
 }
 

--- a/core/textile/bucket/crypto/crypto.go
+++ b/core/textile/bucket/crypto/crypto.go
@@ -1,0 +1,174 @@
+package crypto
+
+import (
+	"bytes"
+	b64 "encoding/base64"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/FleekHQ/space-daemon/log"
+)
+
+func parseKeys(key []byte) (aesKey, iv, hmacKey []byte, err error) {
+	if len(key) != aesKeySize+ivKeySize+hmacKeySize {
+		return nil, nil, nil, errors.New("unsupported encryption keys provided.")
+	}
+
+	return key[:aesKeySize], key[aesKeySize:(aesKeySize + ivKeySize)], key[(aesKeySize + ivKeySize):], nil
+}
+
+// EncryptPathItems returns an encrypted path and a Reader that reads the encrypted data from the
+// plain reader passed into the function.
+// Encrypted data is AES-CTR of data + AES-512 HMAC of encrypted data
+//
+// NOTE: key must be a 64 byte long key
+// To decrypt the result of this function use the DecryptPathItems function
+func EncryptPathItems(key []byte, path string, plainReader io.Reader) (string, io.Reader, error) {
+	// split key into key and secret
+	// use key and secret and IV
+
+	// encrypt path
+	aesKey, iv, hmacKey, err := parseKeys(key)
+	if err != nil {
+		return "", nil, err
+	}
+
+	encryptedPath := ""
+	pathParts := strings.Split(path, "/")
+	pathPartsLen := len(pathParts)
+	for i, pathItem := range pathParts {
+		if pathItem == "" {
+			continue
+		}
+		encryptedPathReader, err := NewEncryptReader(
+			strings.NewReader(pathItem),
+			aesKey,
+			iv,
+			hmacKey,
+		)
+		if err != nil {
+			return "", nil, err
+		}
+
+		encryptedPathItem, err := readAsBase64Strings(encryptedPathReader)
+		if err != nil {
+			return "", nil, err
+		}
+		encryptedPath += encryptedPathItem
+		if i != pathPartsLen-1 {
+			encryptedPath += "/"
+		}
+	}
+
+	// encrypt data
+	var encryptedReader io.Reader
+	if plainReader != nil {
+		var err error
+		encryptedReader, err = NewEncryptReader(
+			plainReader,
+			aesKey,
+			iv,
+			hmacKey,
+		)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	return encryptedPath, encryptedReader, nil
+}
+
+// DecryptPathItems returns a decrypted path string and an io.Reader that reads the decrypted data from the
+// encrypted reader passed into the function.
+// To only decrypt a path, pass in an empty byte buffer as the reader and check only for the string result.
+//
+// NOTE: key must be a 64 byte long key
+func DecryptPathItems(key []byte, path string, encryptedReader io.Reader) (string, io.ReadCloser, error) {
+	// decrypt path
+	log.Debug("Decrypting Path Items", "path:"+path)
+	aesKey, iv, hmacKey, err := parseKeys(key)
+	if err != nil {
+		return "", nil, err
+	}
+
+	decryptedPath := ""
+	pathParts := strings.Split(path, "/")
+	pathPartsLen := len(pathParts)
+	for i, pathItem := range pathParts {
+		if pathItem == "" {
+			continue
+		}
+		encryptedEntryNameBytes, err := bytesFromBase64Strings(pathItem)
+		if err != nil {
+			return "", nil, err
+		}
+
+		decryptedPathReader, err := NewDecryptReader(
+			bytes.NewBuffer(encryptedEntryNameBytes),
+			aesKey,
+			iv,
+			hmacKey,
+		)
+		if err != nil {
+			return "", nil, err
+		}
+
+		decryptedPathItem, err := readBufferString(decryptedPathReader)
+		if err != nil {
+			return "", nil, err
+		}
+
+		decryptedPath += decryptedPathItem
+		if i != pathPartsLen-1 {
+			decryptedPath += "/"
+		}
+	}
+
+	// decrypt data
+	var decryptedReader io.ReadCloser
+	if encryptedReader != nil {
+		var err error
+		decryptedReader, err = NewDecryptReader(
+			encryptedReader,
+			aesKey,
+			iv,
+			hmacKey,
+		)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	return decryptedPath, decryptedReader, nil
+}
+
+func readBufferString(buf io.Reader) (string, error) {
+	builder := new(strings.Builder)
+	_, err := io.Copy(builder, buf)
+	if err != nil {
+		return "", err
+	}
+
+	return builder.String(), nil
+}
+
+func readAsBase64Strings(buf io.Reader) (string, error) {
+	data, err := ioutil.ReadAll(buf)
+	if err != nil {
+		return "", err
+	}
+
+	encodedData := b64.URLEncoding.EncodeToString(data)
+	return encodedData, nil
+}
+
+func bytesFromBase64Strings(data string) ([]byte, error) {
+	decodedData, err := b64.URLEncoding.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodedData, nil
+}

--- a/core/textile/bucket/crypto/crypto_test.go
+++ b/core/textile/bucket/crypto/crypto_test.go
@@ -1,0 +1,68 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var validKeysSize = 80
+
+func Test_EncryptPathItems_Fails_For_InvalidKeys(t *testing.T) {
+	assert := require.New(t)
+
+	key := make([]byte, 64)
+	_, _ = rand.Read(key)
+
+	_, _, err := EncryptPathItems(key, "", bytes.NewBufferString(""))
+	assert.Error(err, "Encrypt Path Item with wrong key should fail")
+}
+
+func Test_DecryptPathItems_Fails_For_InvalidKeys(t *testing.T) {
+	assert := require.New(t)
+
+	key := make([]byte, 64)
+	_, _ = rand.Read(key)
+
+	_, _, err := DecryptPathItems(key, "", bytes.NewBufferString(""))
+	assert.Error(err, "Decrypt Path Item with wrong key should fail")
+}
+
+func Test_EncryptPathItems_Works_With_DecryptPathItems(t *testing.T) {
+	assert := require.New(t)
+
+	key := make([]byte, validKeysSize)
+	_, _ = rand.Read(key)
+	plainPath := "smiggle/was/here"
+	plainData := "This is the original unencrypted data"
+
+	encryptedPath, encryptedReader, err := EncryptPathItems(key, plainPath, bytes.NewBufferString(plainData))
+	assert.NoError(err, "Error encrypting Path Items")
+	assert.NotEqual(encryptedPath, plainPath, "Encrypted Path is equal to Plain Path")
+
+	decryptedPath, decryptedReader, err := DecryptPathItems(key, encryptedPath, encryptedReader)
+	assert.NoError(err, "Error decrypting Path Items")
+	assert.Equal(plainPath, decryptedPath, "Plain Path is not equal to decrypted path")
+	decryptedData, err := ioutil.ReadAll(decryptedReader)
+	assert.NoError(err)
+	assert.Equal(plainData, bytes.NewBuffer(decryptedData).String(), "Plain data is not equal to decrypted data")
+}
+
+func Test_EncryptPathItems_And_DecryptPathItems_Work_With_TopLevel_Files(t *testing.T) {
+	assert := require.New(t)
+
+	key := make([]byte, validKeysSize)
+	_, _ = rand.Read(key)
+	plainPath := "single_directory_entry"
+
+	encryptedPath, _, err := EncryptPathItems(key, plainPath, nil)
+	assert.NoError(err, "Error encrypting Path Items")
+	assert.NotEqual(encryptedPath, plainPath, "Encrypted Path is equal to Plain Path")
+
+	decryptedPath, _, err := DecryptPathItems(key, encryptedPath, nil)
+	assert.NoError(err, "Error decrypting Path Items")
+	assert.Equal(plainPath, decryptedPath, "Plain Path is not equal to decrypted path")
+}

--- a/core/textile/bucket/crypto/decrypter.go
+++ b/core/textile/bucket/crypto/decrypter.go
@@ -1,0 +1,98 @@
+package crypto
+
+import (
+	"bufio"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"errors"
+	"io"
+	"os"
+
+	"github.com/odeke-em/go-utils/tmpfile"
+)
+
+const _16KB = 16 * 1024
+
+var DecryptErr = errors.New("message corrupt or incorrect keys")
+
+// NewDecryptReader creates an io.ReadCloser wrapping an io.Reader using the keys and iv
+// to decode the content using AES and verify HMAC.
+func NewDecryptReader(r io.Reader, aesKey, iv, hmacKey []byte) (io.ReadCloser, error) {
+	return newDecryptReader(r, aesKey, iv, hmacKey)
+}
+
+func newDecryptReader(r io.Reader, aesKey []byte, iv []byte, hmacKey []byte) (io.ReadCloser, error) {
+	mac := make([]byte, hmacSize)
+	h := hmac.New(hashFunc, hmacKey)
+	dst, err := tmpfile.New(&tmpfile.Context{
+		Dir:    os.TempDir(),
+		Suffix: "space-encrypted-",
+	})
+	if err != nil {
+		return nil, err
+	}
+	// If there is an error, try to delete the temp file.
+	defer func() {
+		if err != nil {
+			_ = dst.Done()
+		}
+	}()
+	b, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, err
+	}
+	d := &decryptReader{
+		tmpFile: dst,
+		sReader: &cipher.StreamReader{R: dst, S: cipher.NewCTR(b, iv)},
+	}
+	w := io.MultiWriter(h, dst)
+	buf := bufio.NewReaderSize(r, _16KB)
+	for {
+		b, err := buf.Peek(_16KB)
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if err == io.EOF {
+			left := buf.Buffered()
+			if left < hmacSize {
+				return nil, DecryptErr
+			}
+			copy(mac, b[left-hmacSize:left])
+			_, err = io.CopyN(w, buf, int64(left-hmacSize))
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
+		_, err = io.CopyN(w, buf, _16KB-hmacSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !hmac.Equal(mac, h.Sum(nil)) {
+		return nil, DecryptErr
+	}
+
+	if _, err = dst.Seek(0, 0); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// decryptReader wraps a io.Reader decrypting its content.
+type decryptReader struct {
+	tmpFile *tmpfile.TmpFile
+	sReader *cipher.StreamReader
+}
+
+// Read implements io.Reader.
+func (d *decryptReader) Read(dst []byte) (int, error) {
+	return d.sReader.Read(dst)
+}
+
+// Close implements io.Closer.
+func (d *decryptReader) Close() error {
+	return d.tmpFile.Done()
+}

--- a/core/textile/bucket/crypto/encrypter.go
+++ b/core/textile/bucket/crypto/encrypter.go
@@ -1,0 +1,74 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha512"
+	"errors"
+	"hash"
+	"io"
+)
+
+const (
+	aesKeySize  = 32
+	ivKeySize   = 16
+	hmacKeySize = 32
+	hmacSize    = 64
+)
+
+var hashFunc = sha512.New
+
+// hashReadWriter hashes on write and on read finalizes the hash and returns it.
+// Writes after a Read will return an error.
+type hashReadWriter struct {
+	hash hash.Hash
+	done bool
+	sum  io.Reader
+}
+
+// Write implements io.Writer
+func (h *hashReadWriter) Write(p []byte) (int, error) {
+	if h.done {
+		return 0, errors.New("writing to hashReadWriter after read is not allowed")
+	}
+	return h.hash.Write(p)
+}
+
+// Read implements io.Reader.
+func (h *hashReadWriter) Read(p []byte) (int, error) {
+	if !h.done {
+		h.done = true
+		h.sum = bytes.NewReader(h.hash.Sum(nil))
+	}
+	return h.sum.Read(p)
+}
+
+// NewEncryptReader returns an io.Reader wrapping the provided io.Reader.
+func NewEncryptReader(r io.Reader, aesKey, iv, hmacKey []byte) (io.Reader, error) {
+	if len(aesKey) != aesKeySize {
+		return nil, errors.New("encryption key has incorrect length")
+	}
+
+	if len(iv) != ivKeySize {
+		return nil, errors.New("encryption initialization vector size has incorrect length")
+	}
+
+	if len(hmacKey) != hmacKeySize {
+		return nil, errors.New("encryption hmac key has incorrect length")
+	}
+
+	return newEncryptReader(r, aesKey, iv, hmacKey)
+}
+
+func newEncryptReader(r io.Reader, aesKey, iv, hmacKey []byte) (io.Reader, error) {
+	b, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, err
+	}
+	h := hmac.New(hashFunc, hmacKey)
+	hr := &hashReadWriter{hash: h}
+	sr := &cipher.StreamReader{R: r, S: cipher.NewCTR(b, iv)}
+	return io.MultiReader(io.TeeReader(sr, hr), hr), nil
+}

--- a/core/textile/common/common.go
+++ b/core/textile/common/common.go
@@ -1,0 +1,18 @@
+package common
+
+import "context"
+
+// NewBucketEncryptionKeyContext adds the encryption key to the context
+// which is used to encrypt and decrypt requests to buckets client.
+func NewBucketEncryptionKeyContext(ctx context.Context, key []byte) context.Context {
+	if key == nil || len(key) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, "bucketEncryptionKey", key)
+}
+
+// BucketEncryptionKeyFromContext returns the bucket encryption key from a context.
+func BucketEncryptionKeyFromContext(ctx context.Context) ([]byte, bool) {
+	key, ok := ctx.Value("bucketEncryptionKey").([]byte)
+	return key, ok
+}

--- a/core/textile/secure_bucket_client.go
+++ b/core/textile/secure_bucket_client.go
@@ -1,0 +1,186 @@
+package textile
+
+import (
+	"context"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/FleekHQ/space-daemon/core/textile/common"
+
+	"github.com/FleekHQ/space-daemon/log"
+
+	"github.com/FleekHQ/space-daemon/core/textile/bucket/crypto"
+
+	"github.com/ipfs/interface-go-ipfs-core/path"
+	bc "github.com/textileio/textile/api/buckets/client"
+	bucketsClient "github.com/textileio/textile/api/buckets/client"
+	bucketspb "github.com/textileio/textile/api/buckets/pb"
+)
+
+var textileRelPathRegex = regexp.MustCompile(`/ip[f|n]s/[^/]*(?P<relPath>/.*)`)
+
+// SecureBucketClient implements the BucketsClient Interface
+// It encrypts data being pushed to the underlying textile client
+// and also decrypts response from the underlying textile client
+type SecureBucketClient struct {
+	client     *bucketsClient.Client
+	bucketSlug string
+}
+
+func NewSecureBucketsClient(
+	client *bucketsClient.Client,
+	bucketSlug string,
+) *SecureBucketClient {
+	return &SecureBucketClient{
+		client:     client,
+		bucketSlug: bucketSlug,
+	}
+}
+
+func (s *SecureBucketClient) PushPath(ctx context.Context, key, path string, reader io.Reader, opts ...bc.Option) (result path.Resolved, root path.Resolved, err error) {
+	path = cleanBucketPath(path)
+	encryptionKey, err := s.getBucketEncryptionKey(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// encrypt path before uploading
+	encryptedPath, encryptedReader, err := s.encryptPathData(ctx, encryptionKey, path, reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.client.PushPath(ctx, key, encryptedPath, encryptedReader)
+
+	// For now ignoring parsing results since it not being used downstream
+	// but putting a TODO here in the meantime
+}
+
+func (s *SecureBucketClient) PullPath(ctx context.Context, key, path string, writer io.Writer, opts ...bc.Option) error {
+	encryptionKey, err := s.getBucketEncryptionKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	encryptedPath, _, err := s.encryptPathData(ctx, encryptionKey, path, nil)
+	if err != nil {
+		return err
+	}
+
+	errs := make(chan error)
+	pipeReader, pipeWriter := io.Pipe()
+
+	// pipe the writes from buckets to reader to be decrypted
+
+	go func() {
+		defer pipeWriter.Close()
+		if err := s.client.PullPath(ctx, key, encryptedPath, pipeWriter, opts...); err != nil {
+			errs <- err
+		}
+	}()
+	go func() {
+		defer close(errs)
+		_, r, err := s.decryptPathData(ctx, encryptionKey, "", pipeReader)
+		if err != nil {
+			errs <- err
+			return
+		}
+		defer r.Close()
+		// copy decrypted reads to original writer
+		if _, err := io.Copy(writer, r); err != nil {
+			errs <- err
+			return
+		}
+	}()
+	return <-errs
+}
+
+func (s *SecureBucketClient) ListPath(ctx context.Context, key, path string) (*bucketspb.ListPathReply, error) {
+	path = cleanBucketPath(path)
+	encryptionKey, err := s.getBucketEncryptionKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedPath, _, err := s.encryptPathData(ctx, encryptionKey, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := s.client.ListPath(ctx, key, encryptedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// decrypt result items
+	for _, item := range result.Item.Items {
+		log.Debug("Processing Result Item", "name:"+item.Name, "path:"+item.Path)
+		if item.Name == ".textileseed" || item.Name == ".textile" {
+			continue
+		}
+		// decrypt file name
+		item.Name, _, err = s.decryptPathData(ctx, encryptionKey, item.Name, nil)
+
+		// decrypts file path
+		matchedPaths := textileRelPathRegex.FindStringSubmatch(item.Path)
+		if len(matchedPaths) > 1 {
+			item.Path, _, err = s.decryptPathData(ctx, encryptionKey, matchedPaths[1], nil)
+		}
+		log.Debug("Processed Result Item", "name:"+item.Name, "path:"+item.Path)
+
+		// Item size is generally (content size + hmac (64 bytes))
+		if item.Size >= 64 {
+			item.Size = item.Size - 64
+		}
+	}
+	return result, err
+}
+
+func (s *SecureBucketClient) RemovePath(ctx context.Context, key, path string, opts ...bc.Option) (path.Resolved, error) {
+	path = cleanBucketPath(path)
+	encryptionKey, err := s.getBucketEncryptionKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// encrypt path before submitting delete
+	encryptedPath, _, err := s.encryptPathData(ctx, encryptionKey, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.RemovePath(ctx, key, encryptedPath, opts...)
+}
+
+func (s *SecureBucketClient) getBucketEncryptionKey(ctx context.Context) ([]byte, error) {
+	if key, exists := common.BucketEncryptionKeyFromContext(ctx); exists {
+		return key, nil
+	}
+	return nil, errors.New("bucket encryption key missing")
+}
+
+func (s *SecureBucketClient) encryptPathData(
+	ctx context.Context,
+	key []byte,
+	path string,
+	dataReader io.Reader,
+) (string, io.Reader, error) {
+	return crypto.EncryptPathItems(key, path, dataReader)
+}
+
+func (s *SecureBucketClient) decryptPathData(
+	ctx context.Context,
+	key []byte,
+	path string,
+	dataReader io.Reader,
+) (string, io.ReadCloser, error) {
+	return crypto.DecryptPathItems(key, path, dataReader)
+}
+
+// Cleans path used to access data in buckets
+// Currently only removes prefix path if exists.
+// would later include logic to normalize paths from other operating systems like windows
+func cleanBucketPath(path string) string {
+	return strings.TrimPrefix(path, "/")
+}

--- a/core/textile/utils/utils.go
+++ b/core/textile/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/rand"
 	"crypto/sha512"
 	"encoding/base32"
 	"encoding/binary"
@@ -67,4 +68,11 @@ func NewDeterministicThreadID(kc keychain.Keychain, threadVariant DeterministicT
 	}
 
 	return thread.ID(buf[:n+numlen]), nil
+}
+
+// randBytes returns random bytes in a byte slice of size.
+func RandBytes(size int) ([]byte, error) {
+	b := make([]byte, size)
+	_, err := rand.Read(b)
+	return b, err
 }

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.2.2
 	github.com/multiformats/go-multibase v0.0.3
 	github.com/multiformats/go-multihash v0.0.13
+	github.com/odeke-em/go-utils v0.0.0-20170224015737-e8ebaed0777a
 	github.com/pkg/errors v0.9.1
 	github.com/radovskyb/watcher v1.0.7
 	github.com/rakyll/statik v0.1.7


### PR DESCRIPTION
**Update**
Now instead of path level encryption keys, we maintain a single encryption key for a bucket and that is re-used to encrypt all paths and their file contents before pushing to IPFS.

**CHANGELOG**
- Add EncryptionKey to bucket schema
- Abstraction around encrypting and decrypting bucket items
- Encrypt and Decrypt ListPath data [ch17961]
- Encrypt and Decrypt PushPath data [ch17942] & [ch17955]
- Encrypt and Decrypt RemovePath data [ch17968]
- Decrypt PullPath data before writing it back [ch17966]

Test include a unit test for the core encryption and decryption logic and for now did manual tests for the critical paths:
- Create a new bucket
- Create a directory
- List created directories and verify contents
- Uploaded a local file
- Fetched/Pulled the file from remote and it shows decrypted locally
- Also fetched the IPFS content hash for files and see that they are encrypted on IPFS
