### PR TITLE
Hotfix: use cfg values for txl hub key and secret

### DIFF
--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -69,7 +69,7 @@ func (tc *textileClient) getHubCtx(ctx context.Context) (context.Context, error)
 	log.Debug("Authenticating with Textile Hub")
 
 	// TODO: Use hub.GetHubToken instead
-	ctx, err := hub.GetHubTokenUsingTextileKeys(ctx, tc.store, tc.kc, tc.ht)
+	ctx, err := hub.GetHubTokenUsingTextileKeys(ctx, tc.store, tc.kc, tc.ht, tc.cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/core/textile/hub/hub_auth.go
+++ b/core/textile/hub/hub_auth.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"context"
 	"errors"
-	"os"
 	"time"
 
 	"github.com/FleekHQ/space-daemon/config"
@@ -150,13 +149,13 @@ func GetHubToken(ctx context.Context, st store.Store, kc keychain.Keychain, cfg 
 
 // This method is just for testing purposes. Keys shouldn't be bundled in the daemon.
 // Use GetHubToken instead.
-func GetHubTokenUsingTextileKeys(ctx context.Context, st store.Store, kc keychain.Keychain, threads *threadsClient.Client) (context.Context, error) {
+func GetHubTokenUsingTextileKeys(ctx context.Context, st store.Store, kc keychain.Keychain, threads *threadsClient.Client, cfg config.Config) (context.Context, error) {
 	var tokStr string
 
 	// prebuild context, needs to happen
 	// whether token is saved or not
-	key := os.Getenv("TXL_USER_KEY")
-	secret := os.Getenv("TXL_USER_SECRET")
+	key := cfg.GetString(config.TextileUserKey, "")
+	secret := cfg.GetString(config.TextileUserSecret, "")
 
 	if key == "" || secret == "" {
 		return nil, errors.New("Couldn't get Textile key or secret from envs")


### PR DESCRIPTION
Was investigating @gpuente 's issue on the binary failing if the envs weren't there which was incorrect since they should already be injected into the binary.  Looks like these 2 fields were still being brought in by env vars directly instead of the config file.