### PR TITLE
Hotfix/embedded ipfs node: in dev mode the repo path was being set to emtpy

### DIFF
--- a/config/map_config.go
+++ b/config/map_config.go
@@ -28,6 +28,9 @@ func NewMap(envVal env.SpaceEnv, flags *Flags) Config {
 		configStr[Ipfsaddr] = os.Getenv(env.IpfsAddr)
 		configStr[Ipfsnodeaddr] = os.Getenv(env.IpfsNodeAddr)
 
+		// NOTE: this is a temp fix since it's not happening
+		// on other vars.  real fix could be using viper like
+		// @maurycy suggested
 		if os.Getenv(env.IpfsNodePath) != "" {
 			configStr[Ipfsnodepath] = os.Getenv(env.IpfsNodePath)
 		}
@@ -51,8 +54,15 @@ func NewMap(envVal env.SpaceEnv, flags *Flags) Config {
 		}
 	} else {
 		configStr[Ipfsaddr] = flags.Ipfsaddr
-		configStr[Ipfsnodeaddr] = flags.Ipfsnodeaddr
-		configStr[Ipfsnodeaddr] = flags.Ipfsnodepath
+
+		if flags.Ipfsnodeaddr != "" {
+			configStr[Ipfsnodeaddr] = flags.Ipfsnodeaddr
+		}
+
+		if flags.Ipfsnodepath != "" {
+			configStr[Ipfsnodepath] = flags.Ipfsnodepath
+		}
+
 		configStr[Mongousr] = flags.Mongousr
 		configStr[Mongopw] = flags.Mongopw
 		configStr[Mongohost] = flags.Mongohost

--- a/config/map_config.go
+++ b/config/map_config.go
@@ -27,7 +27,11 @@ func NewMap(envVal env.SpaceEnv, flags *Flags) Config {
 	if flags.DevMode {
 		configStr[Ipfsaddr] = os.Getenv(env.IpfsAddr)
 		configStr[Ipfsnodeaddr] = os.Getenv(env.IpfsNodeAddr)
-		configStr[Ipfsnodepath] = os.Getenv(env.IpfsNodePath)
+
+		if os.Getenv(env.IpfsNodePath) != "" {
+			configStr[Ipfsnodepath] = os.Getenv(env.IpfsNodePath)
+		}
+
 		configStr[Mongousr] = os.Getenv(env.MongoUsr)
 		configStr[Mongopw] = os.Getenv(env.MongoPw)
 		configStr[Mongohost] = os.Getenv(env.MongoHost)


### PR DESCRIPTION
The `cfg.GetString` logic checks if the key exists so it doesn't block out empty strs.  In dev mode, it was being set to empty via a missing env vars.