### PR TITLE
don't block <-component.WaitForReady() on err

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -224,7 +224,10 @@ func (a *App) RunAsync(name string, component core.AsyncComponent, fn func() err
 
 	a.eg.Go(func() error {
 		err := fn()
-		errc <- err
+		if err != nil {
+			errc <- err
+		}
+
 		return err
 	})
 


### PR DESCRIPTION
The issue is that any `RunAsync()` `func` silently blocks the `app.Start()` on error, ie:

```golang
func (a *App) RunAsync(name string, component core.AsyncComponent, fn func() error) {
[...]

	a.eg.Go(func() error {
		return fn()
	})

	<-component.WaitForReady()
```

but:

```golang
func (tb *TextileBuckd) Start(ctx context.Context) error {
[...]

	usr, err := user.Current()
	if err != nil {
		return err
	}

[...]

	tb.IsRunning = true
	tb.Ready <- true
	return nil
}
```

Also, we're not showing any error returned by `RunAsync()` `func`.

The pull request aims to fix both.