### PR TITLE
Set ulimit on start

### DIFF
--- a/cmd/space-daemon/main.go
+++ b/cmd/space-daemon/main.go
@@ -114,6 +114,11 @@ func main() {
 }
 
 func setULimit() {
+	if runtime.GOOS == "windows" {
+		// Only available on UNIX systems
+		return
+	}
+
 	var rLimit syscall.Rlimit
 
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)

--- a/core/util/rlimit/rlimit_unix.go
+++ b/core/util/rlimit/rlimit_unix.go
@@ -1,0 +1,34 @@
+// +build aix darwin dragonfly freebsd js,wasm linux nacl netbsd openbsd solaris
+
+package rlimit
+
+import (
+	"fmt"
+	"math"
+	"syscall"
+
+	"github.com/FleekHQ/space-daemon/log"
+)
+
+// Sets rlimit to the maximum allowed value in UNIX systems
+func SetRLimit() {
+	var rLimit syscall.Rlimit
+
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		log.Error("Error Getting Rlimit. Please run `ulimit -n 1000` from a privileged user to avoid issues when running the space daemon.", err)
+		return
+	}
+	log.Debug(fmt.Sprintf("Got Rlimit: Cur: %d, Max: %d", rLimit.Cur, rLimit.Max))
+
+	// Max allowed value is 10240 even when rLimit.Max can go beyond that
+	rLimit.Cur = uint64(math.Min(10240, float64(rLimit.Max)))
+
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		log.Error("Error setting Rlimit. Please run `ulimit -n 1000` from a privileged user to avoid issues when running the space daemon.", err)
+		return
+	}
+
+	log.Debug(fmt.Sprintf("Set Rlimit: Cur: %d, Max: %d", rLimit.Cur, rLimit.Max))
+}

--- a/core/util/rlimit/rlimit_windows.go
+++ b/core/util/rlimit/rlimit_windows.go
@@ -1,0 +1,6 @@
+package rlimit
+
+// Rlimit not supported on windows
+func SetRLimit() {
+	return
+}

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,7 @@ github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
+github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Was trying to fix the `too many open files` error. Followed some leads and saw this https://docs.mongodb.com/manual/reference/ulimit/#:~:text=Most%20UNIX%2Dlike%20operating%20systems,using%20too%20many%20system%20resources and this https://github.com/ipfs/go-ipfs/issues/4589#issuecomment-358746222

After setting ulimit to a very high value, the problem seemed to be fixed. In this PR I am setting the ulimit value to the maximum possible on startup. Need further testing in other machines.

[ch18171]