### PR TITLE
Hotfix/sharing: A couple fixes to make create-share work

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -117,8 +117,10 @@ func (a *App) Start(ctx context.Context) error {
 		return err
 	}
 
+	hubAuth := hub.New(appStore, kc, a.cfg)
+
 	// setup textile client
-	textileClient := textile.NewClient(appStore, kc)
+	textileClient := textile.NewClient(appStore, kc, hubAuth)
 	err = a.RunAsync("TextileClient", textileClient, func() error {
 		return textileClient.Start(ctx, a.cfg)
 	})

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -44,7 +44,7 @@ type textileClient struct {
 }
 
 // Creates a new Textile Client
-func NewClient(store db.Store, kc keychain.Keychain) *textileClient {
+func NewClient(store db.Store, kc keychain.Keychain, hubAuth hub.HubAuth) *textileClient {
 	return &textileClient{
 		store:            store,
 		kc:               kc,
@@ -59,7 +59,7 @@ func NewClient(store db.Store, kc keychain.Keychain) *textileClient {
 		keypairDeleted:   make(chan bool),
 		shuttingDown:     make(chan bool),
 		isConnectedToHub: false,
-		hubAuth:          nil,
+		hubAuth:          hubAuth,
 	}
 }
 
@@ -86,7 +86,6 @@ func (tc *textileClient) getHubCtx(ctx context.Context) (context.Context, error)
 // Starts the Textile Client
 func (tc *textileClient) start(ctx context.Context, cfg config.Config) error {
 	tc.cfg = cfg
-	tc.hubAuth = hub.New(tc.store, tc.kc, cfg)
 	auth := common.Credentials{}
 	var opts []grpc.DialOption
 

--- a/core/textile/mailbox.go
+++ b/core/textile/mailbox.go
@@ -15,14 +15,18 @@ type UsersClient interface {
 }
 
 func (tc *textileClient) SendMessage(ctx context.Context, recipient crypto.PubKey, body []byte) (*client.Message, error) {
-	var privateKey crypto.PrivKey
 	var err error
+	hubCtx, err := tc.getHubCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var privateKey crypto.PrivKey
 	if privateKey, _, err = tc.kc.GetStoredKeyPairInLibP2PFormat(); err != nil {
 		return nil, err
 	}
 	id := thread.NewLibp2pIdentity(privateKey)
 
-	msg, err := tc.uc.SendMessage(ctx, id, thread.NewLibp2pPubKey(recipient), body)
+	msg, err := tc.uc.SendMessage(hubCtx, id, thread.NewLibp2pPubKey(recipient), body)
 	if err != nil {
 		return nil, err
 	}

--- a/core/textile/mailbox_test.go
+++ b/core/textile/mailbox_test.go
@@ -23,6 +23,7 @@ var (
 	mockKc      *mocks.Keychain
 	mockPubKey  crypto.PubKey
 	mockPrivKey crypto.PrivKey
+	mockHubAuth *mocks.HubAuth
 )
 
 type TearDown func()
@@ -30,7 +31,8 @@ type TearDown func()
 func initTestMailbox(t *testing.T) (tc.Client, TearDown) {
 	st = new(mocks.Store)
 	mockKc = new(mocks.Keychain)
-	client := tc.NewClient(st, mockKc)
+	mockHubAuth = new(mocks.HubAuth)
+	client := tc.NewClient(st, mockKc, mockHubAuth)
 	mockUc = new(mocks.UsersClient)
 	client.SetUc(mockUc)
 
@@ -68,6 +70,7 @@ func TestSendMessage(t *testing.T) {
 		ID: "testid",
 	}
 
+	mockHubAuth.On("GetHubContext", mock.Anything).Return(context.Background(), nil)
 	mockUc.On("SendMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(msg, nil)
 	body := "mockbody"
 	rmsg, err := tc.SendMessage(context.Background(), rp, []byte(body))
@@ -96,6 +99,7 @@ func TestSendMessageFailGettingSenderKey(t *testing.T) {
 		ID: "testid",
 	}
 
+	mockHubAuth.On("GetHubContext", mock.Anything).Return(context.Background(), nil)
 	mockUc.On("SendMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(msg, nil)
 	body := "mockbody"
 	rmsg, err := tc.SendMessage(context.Background(), rp, []byte(body))
@@ -122,6 +126,7 @@ func TestSendMessageFailureOnHub(t *testing.T) {
 
 	msg := uc.Message{}
 
+	mockHubAuth.On("GetHubContext", mock.Anything).Return(context.Background(), nil)
 	mockUc.On("SendMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(msg, errToRet)
 	body := "mockbody"
 	rmsg, err := tc.SendMessage(context.Background(), rp, []byte(body))

--- a/grpc/handlers_sharing.go
+++ b/grpc/handlers_sharing.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"encoding/hex"
 
 	"github.com/FleekHQ/space-daemon/grpc/pb"
 	crypto "github.com/libp2p/go-libp2p-crypto"
@@ -12,7 +13,11 @@ func (srv *grpcServer) ShareFilesViaPublicKey(ctx context.Context, request *pb.S
 	var pks []crypto.PubKey
 
 	for _, pk := range request.PublicKeys {
-		p, err := crypto.UnmarshalEd25519PublicKey([]byte(pk))
+		b, err := hex.DecodeString(pk)
+		if err != nil {
+			return nil, err
+		}
+		p, err := crypto.UnmarshalEd25519PublicKey([]byte(b))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Updates:
* inject hubAuth from the top app.go
* decode hex string properly
* use hub context when sending msg
* update mailbox tests