### PR TITLE
Hotfix/sharing: just like dbid, this makes bucket optional for default buckets

### DIFF
--- a/core/space/services/services_sharing.go
+++ b/core/space/services/services_sharing.go
@@ -252,10 +252,6 @@ func (s *Space) ShareFilesViaPublicKey(ctx context.Context, paths []domain.FullP
 			if err != nil {
 				return err
 			}
-
-			if err != nil {
-				return err
-			}
 			path.Bucket = b.Slug()
 		}
 	}

--- a/core/space/services/services_sharing.go
+++ b/core/space/services/services_sharing.go
@@ -246,6 +246,18 @@ func (s *Space) ShareFilesViaPublicKey(ctx context.Context, paths []domain.FullP
 			}
 			path.DbId = bs.DbID
 		}
+
+		if path.Bucket == "" {
+			b, err := s.tc.GetDefaultBucket(ctx)
+			if err != nil {
+				return err
+			}
+
+			if err != nil {
+				return err
+			}
+			path.Bucket = b.Slug()
+		}
 	}
 
 	for _, pk := range pubkeys {


### PR DESCRIPTION
This is so the FE doesn't have to send the repeated "personal" bucket name for each element in the paths on input (but we still need to have the field on a per path basis because for shared-with-me items they can vary file to file).