### PR TITLE
Hotfix/mirror: fix create mirror on init

### DIFF
--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -351,11 +351,11 @@ func (tc *textileClient) IsRunning() bool {
 func (tc *textileClient) healthcheck(ctx context.Context) {
 	log.Debug("Textile Client healthcheck... Start.")
 
+	tc.checkHubConnection(ctx)
+
 	if tc.isInitialized == false {
 		tc.initialize(ctx)
 	}
-
-	tc.checkHubConnection(ctx)
 
 	switch {
 	case tc.isInitialized == false:

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -351,9 +351,15 @@ func (tc *textileClient) IsRunning() bool {
 func (tc *textileClient) healthcheck(ctx context.Context) {
 	log.Debug("Textile Client healthcheck... Start.")
 
-	tc.checkHubConnection(ctx)
+	// NOTE: since we check for the hub connection before the initialization
+	// this means that a hub connection is required to init for now. Leaving
+	// it like this for release and then we can have a better online vs offline
+	// state management work started asap in parallel (i.e., what happens if
+	// they are offline during init? and then what happens if they come back
+	// online post init and vice versa).
+	err := tc.checkHubConnection(ctx)
 
-	if tc.isInitialized == false {
+	if err == nil && tc.isInitialized == false {
 		tc.initialize(ctx)
 	}
 

--- a/core/textile/mirror.go
+++ b/core/textile/mirror.go
@@ -85,6 +85,12 @@ func (tc *textileClient) createMirrorBucket(ctx context.Context, schema model.Bu
 // Creates a remote hub thread for the mirror bucket
 func (tc *textileClient) createMirrorThread(ctx context.Context) (*thread.ID, error) {
 	log.Debug("createMirrorThread: Generating a new threadID ...")
+	var err error
+	ctx, err = tc.getHubCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	dbID := thread.NewIDV1(thread.Raw, 32)
 
 	log.Debug("createMirrorThread: Creating Thread DB for bucket at db " + dbID.String())


### PR DESCRIPTION
### Change Log
* Create mirror thread was missing hub ctx so fixed that
* Moved `initialize`to after hub connection start to avoid race condition

NOTE: this means that a hub connection is required to init for now.  I think this is okay to release and then we can have a better online vs offline state management work started asap in parallel (i.e., what happens if they are offline during init? and then what happens if they come back online post init and vice versa).  