### PR TITLE
Hotfix/mirror: fixes a few bugs in the mirror bucket and mirror file creation

### DIFF
--- a/core/textile/mirror.go
+++ b/core/textile/mirror.go
@@ -3,8 +3,8 @@ package textile
 import (
 	"context"
 	"io"
-	"os"
 
+	"github.com/FleekHQ/space-daemon/config"
 	"github.com/FleekHQ/space-daemon/core/space/domain"
 	"github.com/FleekHQ/space-daemon/core/textile/model"
 	"github.com/FleekHQ/space-daemon/core/textile/utils"
@@ -47,7 +47,7 @@ func (tc *textileClient) UploadFileToHub(ctx context.Context, b Bucket, path str
 		return nil, nil, err
 	}
 
-	hubCtx, _, err := tc.getBucketContext(ctx, b.Slug(), bucket.RemoteDbID, true, bucket.EncryptionKey)
+	hubCtx, _, err := tc.getBucketContext(ctx, bucket.RemoteDbID, b.Slug(), true, bucket.EncryptionKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -76,9 +76,9 @@ func (tc *textileClient) createMirrorBucket(ctx context.Context, schema model.Bu
 	}
 
 	return &model.MirrorBucketSchema{
-		RemoteDbID:      dbID.String(),
+		RemoteDbID:      utils.CastDbIDToString(*dbID),
 		RemoteBucketKey: b.Root.Key,
-		HubAddr:         os.Getenv("TXL_HUB_TARGET"),
+		HubAddr:         tc.cfg.GetString(config.TextileHubTarget, ""),
 	}, nil
 }
 

--- a/core/textile/model/mirror_file.go
+++ b/core/textile/model/mirror_file.go
@@ -46,6 +46,7 @@ func (m *model) CreateMirrorBucket(ctx context.Context, bucketSlug string, mirro
 
 	bucket.RemoteDbID = mirrorBucket.RemoteDbID
 	bucket.HubAddr = mirrorBucket.HubAddr
+	bucket.RemoteBucketKey = mirrorBucket.RemoteBucketKey
 
 	instances := client.Instances{bucket}
 
@@ -70,12 +71,12 @@ func (m *model) FindMirrorFileByPathAndBucketSlug(ctx context.Context, path, buc
 	}
 
 	if rawMirrorFiles == nil {
-		return nil, errMirrorFileNotFound
+		return &MirrorFileSchema{}, nil
 	}
 
 	mirror_files := rawMirrorFiles.([]*MirrorFileSchema)
 	if len(mirror_files) == 0 {
-		return nil, errMirrorFileNotFound
+		return &MirrorFileSchema{}, nil
 	}
 
 	log.Debug("Model.FindMirrorFileByPathAndBucketSlug: returning mirror file with dbid " + mirror_files[0].DbID)


### PR DESCRIPTION
### Change Log
- `UploadFileToHub` was calling get bucket context with some params swapped
- DbId casting issue
- Were not saving remote bucket key which was needed for lookup
- `FindMirrorFileByPathAndBucketSlug` - don't throw error on not found, instead return empty object (so it doesn't break creation)
- Use `cfg` value instead of OS environ directly for mirror hub addr