### PR TITLE
Hotfix/receivedfiles: handle error and formatting

### DIFF
--- a/grpc/handlers_sharing.go
+++ b/grpc/handlers_sharing.go
@@ -60,7 +60,7 @@ func (srv *grpcServer) GetSharedWithMeFiles(ctx context.Context, request *pb.Get
 	dirEntries := make([]*pb.SharedListDirectoryEntry, 0)
 
 	for _, e := range entries {
-		members := make([]*pb.FileMember, len(e.Members))
+		members := make([]*pb.FileMember, 0)
 
 		for _, m := range e.Members {
 			members = append(members, &pb.FileMember{


### PR DESCRIPTION
### Change Log
* Don't throw if members query throws (this is a temp fix and can be removed once we fix on textile side)
* Fix members list not showing properly
* Fix formatting for size and date fields