### PR TITLE
Hotfix/notifs: dont send extra path item

### DIFF
--- a/grpc/handlers_notif.go
+++ b/grpc/handlers_notif.go
@@ -15,7 +15,7 @@ func mapToPbNotification(n domain.Notification) *pb.Notification {
 	switch n.NotificationType {
 	case domain.INVITATION:
 		inv := n.InvitationValue
-		pbpths := make([]*pb.FullPath, len(inv.ItemPaths))
+		pbpths := make([]*pb.FullPath, 0)
 
 		for _, pth := range n.InvitationValue.ItemPaths {
 			pbpth := &pb.FullPath{


### PR DESCRIPTION
This bug was sending an empty path item before any real path items.