### PR TITLE
Make key generation / restore ops wait for initialization of textile

### DIFF
--- a/core/space/services/services_keypair.go
+++ b/core/space/services/services_keypair.go
@@ -21,11 +21,17 @@ func (s *Space) GenerateKeyPair(ctx context.Context, useForce bool) (string, err
 		return "", err
 	}
 
+	// Wait for textile client to be ready before returning
+	<-s.tc.WaitForHealthy()
+
 	return mnemonic, nil
 }
 
 func (s *Space) RestoreKeyPairFromMnemonic(ctx context.Context, mnemonic string) error {
 	_, err := s.keychain.GenerateKeyFromMnemonic(keychain.WithMnemonic(mnemonic), keychain.WithOverride())
+
+	// Wait for textile client to be ready before returning
+	<-s.tc.WaitForHealthy()
 
 	return err
 }

--- a/core/space/services/services_vault.go
+++ b/core/space/services/services_vault.go
@@ -93,7 +93,7 @@ func (s *Space) RecoverKeysByPassphrase(ctx context.Context, uuid string, pass s
 	}
 
 	// Wait for textile client to be ready before returning
-	<-s.tc.WaitForReady()
+	<-s.tc.WaitForHealthy()
 
 	return nil
 }

--- a/core/space/services/services_vault.go
+++ b/core/space/services/services_vault.go
@@ -59,6 +59,9 @@ func (s *Space) RecoverKeysByLocalBackup(ctx context.Context, path string) error
 		return err
 	}
 
+	// Wait for textile client to be ready before returning
+	<-s.tc.WaitForHealthy()
+
 	return nil
 }
 
@@ -88,6 +91,9 @@ func (s *Space) RecoverKeysByPassphrase(ctx context.Context, uuid string, pass s
 	if err := s.keychain.ImportExistingKeyPair(unmarshalledPriv, privAndMnemonic[1]); err != nil {
 		return err
 	}
+
+	// Wait for textile client to be ready before returning
+	<-s.tc.WaitForReady()
 
 	return nil
 }

--- a/core/space/space_test.go
+++ b/core/space/space_test.go
@@ -671,6 +671,9 @@ func TestService_BackupAndRestore(t *testing.T) {
 	assert.NotNil(t, backup)
 
 	mockKeychain.On("ImportExistingKeyPair", mock.Anything, mock.Anything).Return(nil)
+	mockChan := make(chan bool, 1)
+	mockChan <- true
+	textileClient.On("WaitForHealthy").Return(mockChan)
 
 	err = sv.RecoverKeysByLocalBackup(ctx, path)
 
@@ -727,6 +730,9 @@ func TestService_VaultRestore(t *testing.T) {
 	mockVault.On("Retrieve", uuid, pass).Return(mockItems, nil)
 
 	mockKeychain.On("ImportExistingKeyPair", mock.Anything, mock.Anything).Return(nil)
+	mockChan := make(chan bool, 1)
+	mockChan <- true
+	textileClient.On("WaitForHealthy").Return(mockChan)
 
 	err := sv.RecoverKeysByPassphrase(ctx, uuid, pass)
 	assert.Nil(t, err)

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -154,7 +154,7 @@ func (tc *textileClient) start(ctx context.Context, cfg config.Config) error {
 		timeAfterNextCheck := 60 * time.Second
 		// Do more frequent checks if the client is not initialized/running
 		if tc.isConnectedToHub == false || tc.isInitialized == false {
-			timeAfterNextCheck = 5 * time.Second
+			timeAfterNextCheck = 3 * time.Second
 		}
 
 		// If it's trying to shutdown we return right away

--- a/core/textile/textile.go
+++ b/core/textile/textile.go
@@ -73,6 +73,7 @@ type Client interface {
 	SendMessage(ctx context.Context, recipient crypto.PubKey, body []byte) (*client.Message, error)
 	Shutdown() error
 	WaitForReady() chan bool
+	WaitForHealthy() chan bool
 	Start(ctx context.Context, cfg config.Config) error
 	GetMailAsNotifications(ctx context.Context, seek string, limit int) ([]*domain.Notification, error)
 	ShareFilesViaPublicKey(ctx context.Context, paths []domain.FullPath, pubkeys []crypto.PubKey, keys [][]byte) error

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -504,6 +504,22 @@ func (_m *Client) UploadFileToHub(ctx context.Context, b textile.Bucket, _a2 str
 	return r0, r1, r2
 }
 
+// WaitForHealthy provides a mock function with given fields:
+func (_m *Client) WaitForHealthy() chan bool {
+	ret := _m.Called()
+
+	var r0 chan bool
+	if rf, ok := ret.Get(0).(func() chan bool); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(chan bool)
+		}
+	}
+
+	return r0
+}
+
 // WaitForReady provides a mock function with given fields:
 func (_m *Client) WaitForReady() chan bool {
 	ret := _m.Called()


### PR DESCRIPTION
# Change log

- Solve bug ch18273 where the clientside was requesting stuff from textile client before it was ready (right after account seeding).

[ch18273]