### PR TITLE
Stage specific secrets for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,27 @@ jobs:
       - name: Set secret names
         id: secretnames
         run: |
-          echo "::set-output name=SERVICES_API_URL::SERVICES_API_URL_${{env.STAGE}}"
-          echo "::set-output name=VAULT_API_URL::VAULT_API_URL_${{env.STAGE}}"
-          echo "::set-output name=VAULT_SALT_SECRET::VAULT_SALT_SECRET_${{env.STAGE}}"
-          echo "::set-output name=SERVICES_HUB_AUTH_URL::SERVICES_HUB_AUTH_URL_${{env.STAGE}}"
-          echo "::set-output name=TXL_HUB_TARGET::TXL_HUB_TARGET_${{env.STAGE}}"
-          echo "::set-output name=TXL_HUB_MA::TXL_HUB_MA_${{env.STAGE}}"
-          echo "::set-output name=TXL_THREADS_TARGET::TXL_THREADS_TARGET_${{env.STAGE}}"
-          echo "::set-output name=TXL_USER_KEY::TXL_USER_KEY_${{env.STAGE}}"
-          echo "::set-output name=TXL_USER_SECRET::TXL_USER_SECRET_${{env.STAGE}}"
+          echo $STAGE
+          echo "::set-output name=SERVICES_API_URL::SERVICES_API_URL_${STAGE}"
+          echo "::set-output name=VAULT_API_URL::VAULT_API_URL_${STAGE}"
+          echo "::set-output name=VAULT_SALT_SECRET::VAULT_SALT_SECRET_${STAGE}"
+          echo "::set-output name=SERVICES_HUB_AUTH_URL::SERVICES_HUB_AUTH_URL_${STAGE}"
+          echo "::set-output name=TXL_HUB_TARGET::TXL_HUB_TARGET_${STAGE}"
+          echo "::set-output name=TXL_HUB_MA::TXL_HUB_MA_${STAGE}"
+          echo "::set-output name=TXL_THREADS_TARGET::TXL_THREADS_TARGET_${STAGE}"
+          echo "::set-output name=TXL_USER_KEY::TXL_USER_KEY_${STAGE}"
+          echo "::set-output name=TXL_USER_SECRET::TXL_USER_SECRET_${STAGE}"
+      - name: debug list secret names only
+        run: |
+          echo ${{ steps.secretnames.outputs.SERVICES_API_URL }}
+          echo ${{ steps.secretnames.outputs.VAULT_API_URL }}
+          echo ${{ steps.secretnames.outputs.VAULT_SALT_SECRET }}
+          echo ${{ steps.secretnames.outputs.SERVICES_HUB_AUTH_URL }}
+          echo ${{ steps.secretnames.outputs.TXL_HUB_TARGET }}
+          echo ${{ steps.secretnames.outputs.TXL_HUB_MA }}
+          echo ${{ steps.secretnames.outputs.TXL_THREADS_TARGET }}
+          echo ${{ steps.secretnames.outputs.TXL_USER_KEY }}
+          echo ${{ steps.secretnames.outputs.TXL_USER_SECRET }}
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@master
         with:
@@ -52,12 +64,12 @@ jobs:
           MONGO_PW: ${{ secrets.MONGO_PW }}
           MONGO_HOST: ${{ secrets.MONGO_HOST }}
           MONGO_REPLICA_SET: ${{ secrets.MONGO_REPLICA_SET }}
-          SERVICES_API_URL: ${{ secrets[steps.vars.outputs.SERVICES_API_URL] }}
-          VAULT_API_URL: ${{ secrets[steps.vars.outputs.VAULT_API_URL] }}
-          VAULT_SALT_SECRET: ${{ secrets[steps.vars.outputs.VAULT_SALT_SECRET] }}
-          SERVICES_HUB_AUTH_URL: ${{ secrets[steps.vars.outputs.SERVICES_HUB_AUTH_URL] }}
-          TXL_HUB_TARGET: ${{ secrets[steps.vars.outputs.TXL_HUB_TARGET] }}
-          TXL_HUB_MA: ${{ secrets[steps.vars.outputs.TXL_HUB_MA] }}
-          TXL_THREADS_TARGET: ${{ secrets[steps.vars.outputs.TXL_THREADS_TARGET] }}
-          TXL_USER_KEY: ${{ secrets[steps.vars.outputs.TXL_USER_KEY] }}
-          TXL_USER_SECRET: ${{ secrets[steps.vars.outputs.TXL_USER_SECRET] }}
+          SERVICES_API_URL: ${{ secrets[steps.secretnames.outputs.SERVICES_API_URL] }}
+          VAULT_API_URL: ${{ secrets[steps.secretnames.outputs.VAULT_API_URL] }}
+          VAULT_SALT_SECRET: ${{ secrets[steps.secretnames.outputs.VAULT_SALT_SECRET] }}
+          SERVICES_HUB_AUTH_URL: ${{ secrets[steps.secretnames.outputs.SERVICES_HUB_AUTH_URL] }}
+          TXL_HUB_TARGET: ${{ secrets[steps.secretnames.outputs.TXL_HUB_TARGET] }}
+          TXL_HUB_MA: ${{ secrets[steps.secretnames.outputs.TXL_HUB_MA] }}
+          TXL_THREADS_TARGET: ${{ secrets[steps.secretnames.outputs.TXL_THREADS_TARGET] }}
+          TXL_USER_KEY: ${{ secrets[steps.secretnames.outputs.TXL_USER_KEY] }}
+          TXL_USER_SECRET: ${{ secrets[steps.secretnames.outputs.TXL_USER_SECRET] }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Set stage to ptd
         if: endsWith(github.ref, '/master')
         run: |
-          echo "::set-env name=STAGE::prd"
+          echo "::set-env name=STAGE::PRD"
       - name: Set stage to dev
         if: endsWith(github.ref, '/alpha-release-dev') || endsWith(github.ref, '/develop')
         run: |
-          echo "::set-env name=STAGE::dev"
+          echo "::set-env name=STAGE::DEV"
       - name: Set secret names
         id: secretnames
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,26 @@ jobs:
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
+      - name: Set stage to ptd
+        if: endsWith(github.ref, '/master')
+        run: |
+          echo "::set-env name=STAGE::prd"
+      - name: Set stage to dev
+        if: endsWith(github.ref, '/alpha-release-dev') || endsWith(github.ref, '/develop')
+        run: |
+          echo "::set-env name=STAGE::dev"
+      - name: Set secret names
+        id: secretnames
+        run: |
+          echo "::set-output name=SERVICES_API_URL::SERVICES_API_URL_${{env.STAGE}}"
+          echo "::set-output name=VAULT_API_URL::VAULT_API_URL_${{env.STAGE}}"
+          echo "::set-output name=VAULT_SALT_SECRET::VAULT_SALT_SECRET_${{env.STAGE}}"
+          echo "::set-output name=SERVICES_HUB_AUTH_URL::SERVICES_HUB_AUTH_URL_${{env.STAGE}}"
+          echo "::set-output name=TXL_HUB_TARGET::TXL_HUB_TARGET_${{env.STAGE}}"
+          echo "::set-output name=TXL_HUB_MA::TXL_HUB_MA_${{env.STAGE}}"
+          echo "::set-output name=TXL_THREADS_TARGET::TXL_THREADS_TARGET_${{env.STAGE}}"
+          echo "::set-output name=TXL_USER_KEY::TXL_USER_KEY_${{env.STAGE}}"
+          echo "::set-output name=TXL_USER_SECRET::TXL_USER_SECRET_${{env.STAGE}}"
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@master
         with:
@@ -33,12 +53,12 @@ jobs:
           MONGO_PW: ${{ secrets.MONGO_PW }}
           MONGO_HOST: ${{ secrets.MONGO_HOST }}
           MONGO_REPLICA_SET: ${{ secrets.MONGO_REPLICA_SET }}
-          SERVICES_API_URL: ${{ secrets.SERVICES_API_URL }}
-          VAULT_API_URL: ${{ secrets.VAULT_API_URL }}
-          VAULT_SALT_SECRET: ${{ secrets.VAULT_SALT_SECRET }}
-          SERVICES_HUB_AUTH_URL: ${{ secrets.SERVICES_HUB_AUTH_URL }}
-          TXL_HUB_TARGET: ${{ secrets.TXL_HUB_TARGET }}
-          TXL_HUB_MA: ${{ secrets.TXL_HUB_MA }}
-          TXL_THREADS_TARGET: ${{ secrets.TXL_THREADS_TARGET }}
-          TXL_USER_KEY: ${{ secrets.TXL_USER_KEY }}
-          TXL_USER_SECRET: ${{ secrets.TXL_USER_SECRET }}
+          SERVICES_API_URL: ${{ secrets[steps.vars.outputs.SERVICES_API_URL] }}
+          VAULT_API_URL: ${{ secrets[steps.vars.outputs.VAULT_API_URL] }}
+          VAULT_SALT_SECRET: ${{ secrets[steps.vars.outputs.VAULT_SALT_SECRET] }}
+          SERVICES_HUB_AUTH_URL: ${{ secrets[steps.vars.outputs.SERVICES_HUB_AUTH_URL] }}
+          TXL_HUB_TARGET: ${{ secrets[steps.vars.outputs.TXL_HUB_TARGET] }}
+          TXL_HUB_MA: ${{ secrets[steps.vars.outputs.TXL_HUB_MA] }}
+          TXL_THREADS_TARGET: ${{ secrets[steps.vars.outputs.TXL_THREADS_TARGET] }}
+          TXL_USER_KEY: ${{ secrets[steps.vars.outputs.TXL_USER_KEY] }}
+          TXL_USER_SECRET: ${{ secrets[steps.vars.outputs.TXL_USER_SECRET] }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,17 +43,6 @@ jobs:
           echo "::set-output name=TXL_THREADS_TARGET::TXL_THREADS_TARGET_${STAGE}"
           echo "::set-output name=TXL_USER_KEY::TXL_USER_KEY_${STAGE}"
           echo "::set-output name=TXL_USER_SECRET::TXL_USER_SECRET_${STAGE}"
-      - name: debug list secret names only
-        run: |
-          echo ${{ steps.secretnames.outputs.SERVICES_API_URL }}
-          echo ${{ steps.secretnames.outputs.VAULT_API_URL }}
-          echo ${{ steps.secretnames.outputs.VAULT_SALT_SECRET }}
-          echo ${{ steps.secretnames.outputs.SERVICES_HUB_AUTH_URL }}
-          echo ${{ steps.secretnames.outputs.TXL_HUB_TARGET }}
-          echo ${{ steps.secretnames.outputs.TXL_HUB_MA }}
-          echo ${{ steps.secretnames.outputs.TXL_THREADS_TARGET }}
-          echo ${{ steps.secretnames.outputs.TXL_USER_KEY }}
-          echo ${{ steps.secretnames.outputs.TXL_USER_SECRET }}
       - name: Release via goreleaser
         uses: goreleaser/goreleaser-action@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,11 @@ jobs:
         run: |
           brew tap mitchellh/gon
           brew install mitchellh/gon/gon
-      - name: Set stage to ptd
-        if: endsWith(github.ref, '/master')
+      - name: Set stage to prd for all
         run: |
           echo "::set-env name=STAGE::PRD"
-      - name: Set stage to dev
-        if: endsWith(github.ref, '/alpha-release-dev') || endsWith(github.ref, '/develop')
+      - name: Set stage to dev if tagged develop
+        if: endsWith(github.ref, '-dev')
         run: |
           echo "::set-env name=STAGE::DEV"
       - name: Set secret names

--- a/README.md
+++ b/README.md
@@ -186,3 +186,15 @@ server in localhost:6060. See docs how to interact with pprof server here: https
 
 To disable debug mode add this flag to binary arguments
 `-debug=false`
+
+### CI Secrets
+
+Secrets are set by adding them in Github and then specifying them in `release.yml`. Secrets can be constant across environment/stages or be stage specific.
+
+If specified, the release file will dynamically generate the secret name based on the stage by adding a `_DEV` or `_PRD` suffix to the secret name only for the specificed environment variable. It will always use `_PRD` unless the tag ends in `-dev`.  So for example tag `v0.0.15` will use PRD values, while `v0.0.15-dev` will use DEV values.
+
+Stage specific secret names will only be used for secrets `release.yml` that point to the step output instead of the secret name directly (i.e., `SERVICES_API_URL: ${{ secrets[steps.secretnames.outputs.SERVICES_API_URL] }}` instead of `MONGO_REPLICA_SET: ${{ secrets.MONGO_REPLICA_SET }}`.
+
+So to add a new secret:
+* If it's not stage specific then add the secret in GH with no suffix and in `release.yml`, refer to it based on the secret name.
+* If it is stage specific, then create the 2 secrets in GH (ending in `_PRD` and `_DEV`), add the entry in step `secretnames`, and make sure the secret name in the next step points to the step output


### PR DESCRIPTION
This dynamically sets some secrets to have an env/stage suffix, i.e., `_DEV` or `_PRD`. It will always use `_PRD` unless the tag ends in `-dev`.  So for example tag `v0.0.15` will use PRD values, while `v0.0.15-dev` will use DEV values.

DEV secrets have already been added To GH.  Once this is approved I will update the existing ones to end in `_PRD` for those secrets that apply.

See README section on CI Secrets for more information.