### PR TITLE
Remove CGO_ENABLED env

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,8 @@ before:
 project_name: space
 builds:
   - id: space
-    env:
-      - CGO_ENABLED=0
+    # env:
+    #   - CGO_ENABLED=0
     ldflags:
       - -s -w -X main.mongousr={{ .Env.MONGO_USR }}
       - -X main.mongopw={{ .Env.MONGO_PW }}
@@ -31,8 +31,8 @@ builds:
       - linux
 
   - id: space-darwin
-    env:
-      - CGO_ENABLED=0
+    # env:
+    #   - CGO_ENABLED=0
     ldflags:
       - -s -w -X main.mongousr={{ .Env.MONGO_USR }}
       - -X main.mongopw={{ .Env.MONGO_PW }}
@@ -56,8 +56,8 @@ builds:
     #   post: gon -log-level debug ci/gon.hcl
 
   - id: space-win
-    env:
-      - CGO_ENABLED=0
+    # env:
+    #   - CGO_ENABLED=0
     ldflags:
       - -s -w -X main.mongousr={{ .Env.MONGO_USR }}
       - -X main.mongopw={{ .Env.MONGO_PW }}

--- a/core/keychain/keychain.go
+++ b/core/keychain/keychain.go
@@ -3,6 +3,8 @@ package keychain
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"os"
+	"path"
 	"strings"
 
 	"errors"
@@ -263,14 +265,34 @@ func (kc *keychain) getKeyRing() (ri.Keyring, error) {
 		return kc.ring, nil
 	}
 
+	ucd, err := os.UserConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
 	return keyring.Open(keyring.Config{
-		ServiceName:                    "space",
-		FileDir:                        kc.fileDir + "/kc",
-		PassDir:                        kc.fileDir + "/kcpw",
-		PassPrefix:                     "space",
-		WinCredPrefix:                  "space",
+		ServiceName: "space",
+
+		// MacOS keychain
 		KeychainTrustApplication:       true,
 		KeychainAccessibleWhenUnlocked: true,
+
+		// KDE Wallet
+		KWalletAppID:  "space",
+		KWalletFolder: "space",
+
+		// Windows
+		WinCredPrefix: "space",
+
+		// freedesktop.org's Secret Service
+		LibSecretCollectionName: "space",
+
+		// Pass (https://www.passwordstore.org/)
+		PassPrefix: "space",
+		PassDir:    kc.fileDir + "/kcpw",
+
+		// Fallback encrypted file
+		FileDir: path.Join(ucd, "space", "keyring"),
 	})
 }
 


### PR DESCRIPTION
# Change log

- Removed the `CGO_ENABLED=0` env in goreleaser, which was breaking up keychain on runtime. Weird thing is that if I do `CGO_ENABLED=1` it crashes on compilation (as goreleaser does not support CGO). So not sure why removing the env is both fixing the keychain issue and not crashing goreleaser. But anyways, tested a release (v0.0.16-dev) and it completes successfully and fixes the keychain segfault. Tested common daemon operations and they were all working.

[ch18315]