### PR TITLE
Fix list files decryption

### DIFF
--- a/core/textile/bucket_factory.go
+++ b/core/textile/bucket_factory.go
@@ -154,6 +154,10 @@ func (tc *textileClient) listBuckets(ctx context.Context) ([]Bucket, error) {
 
 	result := make([]Bucket, 0)
 	for _, b := range bucketList {
+		// Skip listing the mirror bucket
+		if b.Slug == defaultPersonalMirrorBucketSlug {
+			continue
+		}
 		bucketObj, err := tc.getBucket(ctx, b.Slug, nil)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Change log

- Fix decryption of shared files which was missing decrypting the root item when doing `ListPath` of the buckets client.

- Fix a bug I noticed where the textile client never got initialized because ListBuckets was erroring on the mirror bucket.

[ch18274]