### PR TITLE
members: unmarshal pubk and derive address

### DIFF
--- a/core/textile/sharing.go
+++ b/core/textile/sharing.go
@@ -170,19 +170,24 @@ func (tc *textileClient) GetReceivedFiles(ctx context.Context, accepted bool, se
 
 		members := make([]domain.Member, 0)
 		for pubk, _ := range rs {
-			b, err := hex.DecodeString(pubk)
+			key := &thread.Libp2pPubKey{}
+
+			err = key.UnmarshalString(pubk)
 			if err != nil {
+				log.Error(fmt.Sprintf("key.UnmarshalString(pubk=%+v)", pubk), err)
 				return nil, "", err
 			}
 
-			pk, err := crypto.UnmarshalEd25519PublicKey([]byte(b))
+			pk := key.PubKey
+
+			b, err := pk.Raw()
 			if err != nil {
 				return nil, "", err
 			}
 
 			members = append(members, domain.Member{
 				Address:   address.DeriveAddress(pk),
-				PublicKey: pubk,
+				PublicKey: hex.EncodeToString(b),
 			})
 		}
 
@@ -242,19 +247,24 @@ func (tc *textileClient) GetPathAccessRoles(ctx context.Context, b Bucket, path 
 
 	members := make([]domain.Member, 0)
 	for pubk, _ := range rs {
-		b, err := hex.DecodeString(pubk)
+		key := &thread.Libp2pPubKey{}
+
+		err = key.UnmarshalString(pubk)
 		if err != nil {
+			log.Error(fmt.Sprintf("key.UnmarshalString(pubk=%+v)", pubk), err)
 			return nil, err
 		}
 
-		pk, err := crypto.UnmarshalEd25519PublicKey([]byte(b))
+		pk := key.PubKey
+
+		b, err := pk.Raw()
 		if err != nil {
 			return nil, err
 		}
 
 		members = append(members, domain.Member{
 			Address:   address.DeriveAddress(pk),
-			PublicKey: pubk,
+			PublicKey: hex.EncodeToString(b),
 		})
 	}
 

--- a/core/textile/sharing.go
+++ b/core/textile/sharing.go
@@ -2,6 +2,7 @@ package textile
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -10,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/FleekHQ/space-daemon/core/space/domain"
+	"github.com/FleekHQ/space-daemon/core/util/address"
 	"github.com/FleekHQ/space-daemon/log"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/textileio/go-threads/core/thread"
@@ -168,7 +170,18 @@ func (tc *textileClient) GetReceivedFiles(ctx context.Context, accepted bool, se
 
 		members := make([]domain.Member, 0)
 		for pubk, _ := range rs {
+			b, err := hex.DecodeString(pubk)
+			if err != nil {
+				return nil, "", err
+			}
+
+			pk, err := crypto.UnmarshalEd25519PublicKey([]byte(b))
+			if err != nil {
+				return nil, "", err
+			}
+
 			members = append(members, domain.Member{
+				Address:   address.DeriveAddress(pk),
 				PublicKey: pubk,
 			})
 		}
@@ -229,7 +242,18 @@ func (tc *textileClient) GetPathAccessRoles(ctx context.Context, b Bucket, path 
 
 	members := make([]domain.Member, 0)
 	for pubk, _ := range rs {
+		b, err := hex.DecodeString(pubk)
+		if err != nil {
+			return nil, err
+		}
+
+		pk, err := crypto.UnmarshalEd25519PublicKey([]byte(b))
+		if err != nil {
+			return nil, err
+		}
+
 		members = append(members, domain.Member{
+			Address:   address.DeriveAddress(pk),
 			PublicKey: pubk,
 		})
 	}

--- a/core/textile/sharing.go
+++ b/core/textile/sharing.go
@@ -169,7 +169,7 @@ func (tc *textileClient) GetReceivedFiles(ctx context.Context, accepted bool, se
 		members := make([]domain.Member, 0)
 		for pubk, _ := range rs {
 			members = append(members, domain.Member{
-				Address: pubk,
+				PublicKey: pubk,
 			})
 		}
 
@@ -230,7 +230,7 @@ func (tc *textileClient) GetPathAccessRoles(ctx context.Context, b Bucket, path 
 	members := make([]domain.Member, 0)
 	for pubk, _ := range rs {
 		members = append(members, domain.Member{
-			Address: pubk,
+			PublicKey: pubk,
 		})
 	}
 


### PR DESCRIPTION
Fixes the following wrong values for the wrong fields in the `members`:

```
"members": [
        {
          "publicKey": "",
          "address": "bbaareifnrgcgvevcwepn7opqkr2ynjhgavwf5fpebdl3fnzwp6ajv2i6q4"
        }
      ],
```