### PR TITLE
Hotfix/files: dont crash on missing map entry.

### DIFF
--- a/core/space/services/services_fs.go
+++ b/core/space/services/services_fs.go
@@ -165,6 +165,11 @@ func (s *Space) listDirAtPath(
 			return nil, err
 		}
 
+		backedup := false
+		if mirror_files[item.Path] != nil {
+			backedup = mirror_files[item.Path].Backup
+		}
+
 		entry := domain.FileInfo{
 			DirEntry: domain.DirEntry{
 				Path:          relPath,
@@ -178,7 +183,7 @@ func (s *Space) listDirAtPath(
 				Members: members,
 			},
 			IpfsHash: item.Cid,
-			BackedUp: mirror_files[item.Path].Backup,
+			BackedUp: backedup,
 		}
 		entries = append(entries, entry)
 


### PR DESCRIPTION
Fixes this partially https://app.clubhouse.io/terminalsystems/story/18342/bug-accepting-a-notifcation-causes-space-daemon-crashes.

This fixes it so it at least doesn't crash.  But there is still some other error going on if we are landing at that case because that means mirror file wasn't found.  