### PR TITLE
Hotfix/sharing: bugs related to opening received file

### DIFF
--- a/core/space/services/services_fs.go
+++ b/core/space/services/services_fs.go
@@ -106,7 +106,7 @@ func (s *Space) ToggleBucketBackup(ctx context.Context, bucketName string, bucke
 	return nil
 }
 
-func (s *Space) getBucketForRemoteFile(ctx context.Context, bucketName string, dbID string, path string) (textile.Bucket, error) {
+func (s *Space) getBucketForRemoteFile(ctx context.Context, bucketName, dbID, path string) (textile.Bucket, error) {
 	input := &textile.GetBucketForRemoteFileInput{
 		Bucket: bucketName,
 		DbID:   dbID,

--- a/core/textile/bucket_factory.go
+++ b/core/textile/bucket_factory.go
@@ -183,18 +183,22 @@ func (tc *textileClient) getBucketRootFromReceivedFile(ctx context.Context, file
 		return nil, nil, err
 	}
 
-	bucketListReply, err := tc.hb.List(remoteCtx)
+	sbs := NewSecureBucketsClient(
+		tc.hb,
+		receivedFile.Bucket,
+	)
+
+	b, err := sbs.ListPath(remoteCtx, receivedFile.BucketKey, receivedFile.Path)
+
 	if err != nil {
 		return nil, nil, err
 	}
 
-	for _, root := range bucketListReply.Roots {
-		if root.Name == receivedFile.Bucket {
-			return root, getCtxFn, nil
-		}
+	if b != nil {
+		return b.GetRoot(), getCtxFn, nil
 	}
-	return nil, nil, NotFound(receivedFile.Bucket)
 
+	return nil, nil, NotFound(receivedFile.Bucket)
 }
 
 func (tc *textileClient) getBucketRootFromSlug(ctx context.Context, slug string) (context.Context, *buckets_pb.Root, error) {

--- a/core/textile/secure_bucket_client.go
+++ b/core/textile/secure_bucket_client.go
@@ -98,9 +98,6 @@ func (s *SecureBucketClient) PullPath(ctx context.Context, key, path string, wri
 		return err
 	}
 
-	res, _ := s.client.ListPath(ctx, key, "/")
-	log.Debug("res: " + string(res.Item.Items[1].Path))
-
 	errs := make(chan error)
 	pipeReader, pipeWriter := io.Pipe()
 

--- a/examples/textileBucketsClient/open-share-file/open-share-file.go
+++ b/examples/textileBucketsClient/open-share-file/open-share-file.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"log"
+	"os"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	tc "github.com/textileio/go-threads/api/client"
+	"github.com/textileio/go-threads/core/thread"
+	bc "github.com/textileio/textile/api/buckets/client"
+	buckets_pb "github.com/textileio/textile/api/buckets/pb"
+	"github.com/textileio/textile/api/common"
+	tb "github.com/textileio/textile/buckets"
+	"github.com/textileio/textile/cmd"
+	"google.golang.org/grpc"
+)
+
+type TextileBucketRoot buckets_pb.Root
+
+func main() {
+	host := os.Getenv("TXL_HUB_TARGET")
+	key := os.Getenv("TXL_USER_KEY")
+	secret := os.Getenv("TXL_USER_SECRET")
+
+	var threads *tc.Client
+	var buckets *bc.Client
+	var err error
+	auth := common.Credentials{}
+	var opts []grpc.DialOption
+	hubTarget := host
+	threadstarget := host
+	opts = append(opts, grpc.WithInsecure())
+	opts = append(opts, grpc.WithPerRPCCredentials(auth))
+
+	buckets, err = bc.NewClient(hubTarget, opts...)
+	if err != nil {
+		cmd.Fatal(err)
+	}
+	threads, err = tc.NewClient(threadstarget, opts...)
+	if err != nil {
+		cmd.Fatal(err)
+	}
+
+	user1, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	user2, _, err := crypto.GenerateEd25519Key(rand.Reader)
+
+	// user 1 creates bucket and adds file
+
+	ctx := context.Background()
+	ctx = common.NewAPIKeyContext(ctx, key)
+	ctx, err = common.CreateAPISigContext(ctx, time.Now().Add(time.Minute*2), secret)
+	tok, err := threads.GetToken(ctx, thread.NewLibp2pIdentity(user1))
+	ctx = thread.NewTokenContext(ctx, tok)
+
+	if err != nil {
+		log.Println("error creating APISigContext")
+		log.Fatal(err)
+	}
+
+	bucket1name := "testbucket1"
+
+	ctx = common.NewThreadNameContext(ctx, bucket1name)
+	dbID := thread.NewIDV1(thread.Raw, 32)
+	if err := threads.NewDB(ctx, dbID); err != nil {
+		log.Println("error calling threads.NewDB")
+		log.Fatal(err)
+	}
+
+	ctx = common.NewThreadIDContext(ctx, dbID)
+
+	buck, err := buckets.Create(ctx, bc.WithName(bucket1name), bc.WithPrivate(true))
+	log.Println("created bucket: " + buck.Root.Name)
+
+	filepath := "file1"
+	f := &bytes.Buffer{}
+	f.Write([]byte("hello space"))
+	_, _, err = buckets.PushPath(ctx, buck.Root.Key, filepath, f)
+
+	if err != nil {
+		log.Println("error pushing path")
+		log.Fatal(err)
+	}
+
+	roles := make(map[string]tb.Role)
+	tpk := thread.NewLibp2pPubKey(user2.GetPublic())
+	roles[tpk.String()] = tb.Admin
+	err = buckets.PushPathAccessRoles(ctx, buck.Root.Key, filepath, roles)
+	if err != nil {
+		log.Println("error sharing path")
+		log.Fatal(err)
+	}
+
+	// user 2 tries to access
+	ctx1 := context.Background()
+	ctx1 = common.NewAPIKeyContext(ctx1, key)
+	ctx1, err = common.CreateAPISigContext(ctx1, time.Now().Add(time.Minute*2), secret)
+	tok, err = threads.GetToken(ctx1, thread.NewLibp2pIdentity(user2))
+	ctx1 = thread.NewTokenContext(ctx1, tok)
+
+	if err != nil {
+		log.Println("error creating context")
+		log.Fatal(err)
+	}
+
+	ctx1 = common.NewThreadNameContext(ctx1, bucket1name)
+	ctx1 = common.NewThreadIDContext(ctx1, dbID)
+	var buf bytes.Buffer
+	err = buckets.PullPath(ctx1, buck.Root.Key, filepath, &buf)
+	if err != nil {
+		log.Println("error pulling path")
+		log.Fatal(err)
+	}
+
+	s := buf.String()
+	log.Println("fetch file content: " + s)
+}


### PR DESCRIPTION
### Change Log
* Before it was failing with `user does not own thread` because we were calling `list` buckets but the receiver doesn't have permissions to list all buckets since they only got shared a file (instead of listing all buckets, we now just fetch the path that was shared, and use it's `GetRoot` func to get the bucket root)
* A leftover log that was accessing an array item that was outside the index range - removed that altogether since it was just used for logging
* Added example of sharing and accessing file that helped isolate the issue