### PR TITLE
Multiple bug fixes

### DIFF
--- a/core/space/domain/domain.go
+++ b/core/space/domain/domain.go
@@ -25,8 +25,9 @@ type ThreadInfo struct {
 
 type FileInfo struct {
 	DirEntry
-	IpfsHash string
-	BackedUp bool
+	IpfsHash         string
+	BackedUp         bool
+	LocallyAvailable bool
 }
 
 type OpenFileInfo struct {

--- a/core/space/services/services_fs.go
+++ b/core/space/services/services_fs.go
@@ -195,6 +195,11 @@ func (s *Space) listDirAtPath(
 			backedup = mirror_files[item.Path].Backup
 		}
 
+		locallyAvailable := false
+		if e, _ := b.FileExists(ctx, item.Path); e == true {
+			locallyAvailable = true
+		}
+
 		entry := domain.FileInfo{
 			DirEntry: domain.DirEntry{
 				Path:          relPath,
@@ -207,8 +212,9 @@ func (s *Space) listDirAtPath(
 				Updated: time.Now().Format(time.RFC3339),
 				Members: members,
 			},
-			IpfsHash: item.Cid,
-			BackedUp: backedup,
+			IpfsHash:         item.Cid,
+			BackedUp:         backedup,
+			LocallyAvailable: locallyAvailable,
 		}
 		entries = append(entries, entry)
 

--- a/core/space/space_test.go
+++ b/core/space/space_test.go
@@ -224,6 +224,12 @@ func TestService_ListDirs(t *testing.T) {
 	).Return(mockDirItems, nil)
 
 	mockBucket.On(
+		"FileExists",
+		mock.Anything,
+		mock.Anything,
+	).Return(true, nil)
+
+	mockBucket.On(
 		"ListDirectory",
 		mock.Anything,
 		"/somedir",

--- a/core/textile/bucket/bucket.go
+++ b/core/textile/bucket/bucket.go
@@ -28,6 +28,7 @@ type BucketsClient interface {
 	PullPath(ctx context.Context, key, pth string, writer io.Writer, opts ...bucketsClient.Option) error
 	ListPath(ctx context.Context, key, pth string) (*bucketsproto.ListPathResponse, error)
 	RemovePath(ctx context.Context, key, pth string, opts ...bucketsClient.Option) (path.Resolved, error)
+	ListIpfsPath(ctx context.Context, ipfsPath path.Path) (*bucketsproto.ListIpfsPathResponse, error)
 }
 
 // NOTE: all write operations should use the lock for the bucket to keep consistency

--- a/core/textile/secure_bucket_client.go
+++ b/core/textile/secure_bucket_client.go
@@ -162,6 +162,10 @@ func (s *SecureBucketClient) overwriteDecryptedItem(ctx context.Context, item *b
 	return nil
 }
 
+func (s *SecureBucketClient) ListIpfsPath(ctx context.Context, pth path.Path) (*bucketspb.ListIpfsPathResponse, error) {
+	return s.client.ListIpfsPath(ctx, pth)
+}
+
 func (s *SecureBucketClient) ListPath(ctx context.Context, key, path string) (*bucketspb.ListPathResponse, error) {
 	path = cleanBucketPath(path)
 	encryptionKey, err := s.getBucketEncryptionKey(ctx)

--- a/core/textile/sharing.go
+++ b/core/textile/sharing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -158,7 +159,7 @@ func (tc *textileClient) GetReceivedFiles(ctx context.Context, accepted bool, se
 		name := f.Item.Name
 		isDir := false
 		size := f.GetItem().Size
-		ext := filepath.Ext(name)
+		ext := strings.Replace(filepath.Ext(name), ".", "", -1)
 
 		rs, err := sbc.PullPathAccessRoles(ctx, file.BucketKey, file.Path)
 		if err != nil {
@@ -195,7 +196,9 @@ func (tc *textileClient) GetReceivedFiles(ctx context.Context, accepted bool, se
 			Bucket: file.Bucket,
 			DbID:   file.DbID,
 			FileInfo: domain.FileInfo{
-				IpfsHash: ipfsHash,
+				IpfsHash:         ipfsHash,
+				LocallyAvailable: false,
+				BackedUp:         true,
 				DirEntry: domain.DirEntry{
 					Path:          file.Path,
 					IsDir:         isDir,

--- a/grpc/handlers.go
+++ b/grpc/handlers.go
@@ -58,16 +58,23 @@ func (srv *grpcServer) ListDirectories(ctx context.Context, request *pb.ListDire
 			})
 		}
 
+		var backupCount = 0
+		if e.BackedUp {
+			backupCount = 1
+		}
+
 		dirEntry := &pb.ListDirectoryEntry{
-			Path:          e.Path,
-			IsDir:         e.IsDir,
-			Name:          e.Name,
-			SizeInBytes:   e.SizeInBytes,
-			Created:       e.Created,
-			Updated:       e.Updated,
-			FileExtension: e.FileExtension,
-			IpfsHash:      e.IpfsHash,
-			Members:       members,
+			Path:               e.Path,
+			IsDir:              e.IsDir,
+			Name:               e.Name,
+			SizeInBytes:        e.SizeInBytes,
+			Created:            e.Created,
+			Updated:            e.Updated,
+			FileExtension:      e.FileExtension,
+			IpfsHash:           e.IpfsHash,
+			Members:            members,
+			IsLocallyAvailable: e.LocallyAvailable,
+			BackupCount:        int64(backupCount),
 		}
 		dirEntries = append(dirEntries, dirEntry)
 	}
@@ -106,16 +113,17 @@ func (srv *grpcServer) ListDirectory(
 		}
 
 		dirEntry := &pb.ListDirectoryEntry{
-			Path:          e.Path,
-			IsDir:         e.IsDir,
-			Name:          e.Name,
-			SizeInBytes:   e.SizeInBytes,
-			Created:       e.Created,
-			Updated:       e.Updated,
-			FileExtension: e.FileExtension,
-			IpfsHash:      e.IpfsHash,
-			Members:       members,
-			BackupCount:   int64(backupCount),
+			Path:               e.Path,
+			IsDir:              e.IsDir,
+			Name:               e.Name,
+			SizeInBytes:        e.SizeInBytes,
+			Created:            e.Created,
+			Updated:            e.Updated,
+			FileExtension:      e.FileExtension,
+			IpfsHash:           e.IpfsHash,
+			Members:            members,
+			BackupCount:        int64(backupCount),
+			IsLocallyAvailable: e.LocallyAvailable,
 		}
 		dirEntries = append(dirEntries, dirEntry)
 	}

--- a/grpc/handlers_sharing.go
+++ b/grpc/handlers_sharing.go
@@ -69,19 +69,26 @@ func (srv *grpcServer) GetSharedWithMeFiles(ctx context.Context, request *pb.Get
 			})
 		}
 
+		var backupCount = 0
+		if e.BackedUp {
+			backupCount = 1
+		}
+
 		dirEntry := &pb.SharedListDirectoryEntry{
 			DbId:   e.DbID,
 			Bucket: e.Bucket,
 			Entry: &pb.ListDirectoryEntry{
-				Path:          e.Path,
-				IsDir:         e.IsDir,
-				Name:          e.Name,
-				SizeInBytes:   e.SizeInBytes,
-				Created:       e.Created,
-				Updated:       e.Updated,
-				FileExtension: e.FileExtension,
-				IpfsHash:      e.IpfsHash,
-				Members:       members,
+				Path:               e.Path,
+				IsDir:              e.IsDir,
+				Name:               e.Name,
+				SizeInBytes:        e.SizeInBytes,
+				Created:            e.Created,
+				Updated:            e.Updated,
+				FileExtension:      e.FileExtension,
+				IpfsHash:           e.IpfsHash,
+				Members:            members,
+				IsLocallyAvailable: e.LocallyAvailable,
+				BackupCount:        int64(backupCount),
 			},
 		}
 		dirEntries = append(dirEntries, dirEntry)


### PR DESCRIPTION
# Change log

- Fix [ch18444]: File extension for shared files

- Fix [ch18445]: Return `backedUp` as true for shared files

- Fix [ch18423]: Return `locallyAvailable` as true if files are available locally.

- Fix a bug in `textile/buckets/bucket_file` in the method `FileExists` where it was always returning false.