### PR TITLE
Hotfix/ch18277: show accept/reject on invitations

### DIFF
--- a/core/space/services/sharing_utils.go
+++ b/core/space/services/sharing_utils.go
@@ -20,6 +20,7 @@ func extractInvitation(notification *domain.Notification) (domain.Invitation, er
 		return domain.Invitation{}, errInvitationNotFound
 	}
 
+	notification.InvitationValue.InvitationID = notification.ID
 	return notification.InvitationValue, nil
 }
 

--- a/core/textile/bucket_factory.go
+++ b/core/textile/bucket_factory.go
@@ -85,7 +85,7 @@ func (tc *textileClient) getBucketContext(ctx context.Context, sDbID string, buc
 		log.Error("Error casting thread id", err)
 		return nil, nil, err
 	}
-	ctx, err = utils.GetThreadContext(ctx, bucketSlug, *dbID, ishub, tc.kc, tc.hubAuth)
+	ctx, err = utils.GetThreadContext(ctx, bucketSlug, *dbID, ishub, tc.kc, tc.hubAuth, nil)
 
 	if err != nil {
 		return nil, nil, err

--- a/core/textile/mailbox.go
+++ b/core/textile/mailbox.go
@@ -96,16 +96,17 @@ func (tc *textileClient) parseMessage(ctx context.Context, msgs []client.Message
 				return nil, err
 			}
 
-			if fsmap[i.InvitationID] == nil {
+			if fsmap[msg.ID] == nil {
 				i.Status = domain.PENDING
 			} else {
-				if fsmap[i.InvitationID].Accepted {
+				if fsmap[msg.ID].Accepted {
 					i.Status = domain.ACCEPTED
 				} else {
 					i.Status = domain.REJECTED
 				}
 			}
 
+			i.InvitationID = msg.ID
 			n.InvitationValue = *i
 			n.RelatedObject = *i
 		case domain.USAGEALERT:

--- a/core/textile/mailbox.go
+++ b/core/textile/mailbox.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/FleekHQ/space-daemon/config"
 	"github.com/FleekHQ/space-daemon/core/space/domain"
+	"github.com/FleekHQ/space-daemon/core/textile/model"
 	"github.com/FleekHQ/space-daemon/log"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/textileio/go-threads/core/thread"
@@ -36,60 +37,93 @@ type Mailbox interface {
 	Identity() thread.Identity
 }
 
-func (tc *textileClient) parseMessage(ctx context.Context, msg client.Message) (*domain.Notification, error) {
-	p, err := msg.Open(ctx, tc.mb.Identity())
+func (tc *textileClient) parseMessage(ctx context.Context, msgs []client.Message) ([]*domain.Notification, error) {
+	ns := make([]*domain.Notification, 0)
+
+	ids := []string{}
+	for _, n := range msgs {
+		ids = append(ids, n.ID)
+	}
+
+	fileschemas, err := tc.GetModel().FindReceivedFilesByIds(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
 
-	b := &domain.MessageBody{}
-	err = json.Unmarshal(p, b)
+	// make map so we dont have to iterate each time
+	fsmap := make(map[string]*model.ReceivedFileSchema)
+	for _, fs := range fileschemas {
+		fsmap[fs.InvitationId] = fs
+	}
 
-	if err != nil {
-		log.Error("Error parsing message into MessageBody type", err)
+	for _, msg := range msgs {
+		p, err := msg.Open(ctx, tc.mb.Identity())
+		if err != nil {
+			return nil, err
+		}
 
-		// returning generic notification since body was not able to be parsed
+		b := &domain.MessageBody{}
+		err = json.Unmarshal(p, b)
+
+		if err != nil {
+			log.Error("Error parsing message into MessageBody type", err)
+
+			// returning generic notification since body was not able to be parsed
+			n := &domain.Notification{
+				ID:        msg.ID,
+				Body:      string(p),
+				CreatedAt: msg.CreatedAt.Unix(),
+				ReadAt:    msg.ReadAt.Unix(),
+			}
+
+			ns = append(ns, n)
+			continue
+		}
+
 		n := &domain.Notification{
-			ID:        msg.ID,
-			Body:      string(p),
-			CreatedAt: msg.CreatedAt.Unix(),
-			ReadAt:    msg.ReadAt.Unix(),
+			ID:               msg.ID,
+			Body:             string(p),
+			NotificationType: (*b).Type,
+			CreatedAt:        msg.CreatedAt.Unix(),
+			ReadAt:           msg.ReadAt.Unix(),
 		}
 
-		return n, nil
-	}
+		switch (*b).Type {
+		case domain.INVITATION:
+			i := &domain.Invitation{}
+			err := json.Unmarshal((*b).Body, i)
+			if err != nil {
+				return nil, err
+			}
 
-	n := &domain.Notification{
-		ID:               msg.ID,
-		Body:             string(p),
-		NotificationType: (*b).Type,
-		CreatedAt:        msg.CreatedAt.Unix(),
-		ReadAt:           msg.ReadAt.Unix(),
-	}
+			if fsmap[i.InvitationID] == nil {
+				i.Status = domain.PENDING
+			} else {
+				if fsmap[i.InvitationID].Accepted {
+					i.Status = domain.ACCEPTED
+				} else {
+					i.Status = domain.REJECTED
+				}
+			}
 
-	switch (*b).Type {
-	case domain.INVITATION:
-		i := &domain.Invitation{}
-		err := json.Unmarshal((*b).Body, i)
-		if err != nil {
-			return nil, err
+			n.InvitationValue = *i
+			n.RelatedObject = *i
+		case domain.USAGEALERT:
+			u := &domain.UsageAlert{}
+			err := json.Unmarshal((*b).Body, u)
+
+			if err != nil {
+				return nil, err
+			}
+			n.UsageAlertValue = *u
+			n.RelatedObject = *u
+		default:
 		}
 
-		n.InvitationValue = *i
-		n.RelatedObject = *i
-	case domain.USAGEALERT:
-		u := &domain.UsageAlert{}
-		err := json.Unmarshal((*b).Body, u)
-
-		if err != nil {
-			return nil, err
-		}
-		n.UsageAlertValue = *u
-		n.RelatedObject = *u
-	default:
+		ns = append(ns, n)
 	}
 
-	return n, nil
+	return ns, nil
 }
 
 func (tc *textileClient) SendMessage(ctx context.Context, recipient crypto.PubKey, body []byte) (*client.Message, error) {
@@ -116,7 +150,6 @@ func (tc *textileClient) GetMailAsNotifications(ctx context.Context, seek string
 	}
 
 	var err error
-	ns := []*domain.Notification{}
 
 	ctx, err = tc.getHubCtx(ctx)
 	if err != nil {
@@ -128,13 +161,9 @@ func (tc *textileClient) GetMailAsNotifications(ctx context.Context, seek string
 		return nil, err
 	}
 
-	for _, n := range notifs {
-		notif, err := tc.parseMessage(ctx, n)
-		if err != nil {
-			return nil, err
-		}
-
-		ns = append(ns, notif)
+	ns, err := tc.parseMessage(ctx, notifs)
+	if err != nil {
+		return nil, err
 	}
 
 	return ns, nil
@@ -170,12 +199,12 @@ func (tc *textileClient) listenForMessages(ctx context.Context) error {
 					return
 				}
 
-				p, err := tc.parseMessage(ctx, msg[0])
+				p, err := tc.parseMessage(ctx, msg)
 				if err != nil {
 					log.Error("Unable to parse incoming message: ", err)
 				}
 
-				tc.mbNotifier.SendNotificationEvent(p)
+				tc.mbNotifier.SendNotificationEvent(p[0])
 			case mail.MessageRead:
 				// handle message read (inbox only)
 			case mail.MessageDeleted:

--- a/core/textile/model/model.go
+++ b/core/textile/model/model.go
@@ -45,6 +45,7 @@ type Model interface {
 	CreateMirrorFile(ctx context.Context, mirrorFile *domain.MirrorFile) (*MirrorFileSchema, error)
 	ListReceivedFiles(ctx context.Context, accepted bool, seek string, limit int) ([]*ReceivedFileSchema, error)
 	FindMirrorFileByPaths(ctx context.Context, paths []string) (map[string]*MirrorFileSchema, error)
+	FindReceivedFilesByIds(ctx context.Context, ids []string) ([]*ReceivedFileSchema, error)
 }
 
 func New(st store.Store, kc keychain.Keychain, threads *threadsClient.Client, hubAuth hub.HubAuth) *model {

--- a/core/textile/model/model.go
+++ b/core/textile/model/model.go
@@ -124,7 +124,7 @@ func (m *model) getMetaThreadContext(ctx context.Context) (context.Context, *thr
 		return nil, nil, err
 	}
 
-	metathreadCtx, err := utils.GetThreadContext(ctx, metaThreadName, *dbID, false, m.kc, m.hubAuth)
+	metathreadCtx, err := utils.GetThreadContext(ctx, metaThreadName, *dbID, false, m.kc, m.hubAuth, m.threads)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/textile/model/received_file.go
+++ b/core/textile/model/received_file.go
@@ -85,6 +85,31 @@ func (m *model) CreateReceivedFile(
 	}, nil
 }
 
+func (m *model) FindReceivedFilesByIds(ctx context.Context, ids []string) ([]*ReceivedFileSchema, error) {
+	metaCtx, dbID, err := m.initReceivedFileModel(ctx)
+	if err != nil || dbID == nil {
+		return nil, err
+	}
+
+	var qry *db.Query
+	for i, id := range ids {
+		if i == 0 {
+			qry = db.Where("invitationId").Eq(id)
+		} else {
+			qry = qry.Or(db.Where("invitationId").Eq(id))
+		}
+	}
+
+	fileSchemasRaw, err := m.threads.Find(metaCtx, *dbID, receivedFileModelName, qry, &ReceivedFileSchema{})
+	if err != nil {
+		return nil, err
+	}
+
+	fileSchemas := fileSchemasRaw.([]*ReceivedFileSchema)
+
+	return fileSchemas, nil
+}
+
 // Finds the metadata of a file that has been shared to the user
 func (m *model) FindReceivedFile(ctx context.Context, remoteDbID, bucket, path string) (*ReceivedFileSchema, error) {
 	metaCtx, dbID, err := m.initReceivedFileModel(ctx)

--- a/core/textile/public.go
+++ b/core/textile/public.go
@@ -74,7 +74,7 @@ func (tc *textileClient) getPublicShareBucketContext(ctx context.Context, bucket
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx, err = utils.GetThreadContext(ctx, bucketSlug, dbId, true, tc.kc, tc.hubAuth)
+	ctx, err = utils.GetThreadContext(ctx, bucketSlug, dbId, true, tc.kc, tc.hubAuth, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/grpc/handlers_notif.go
+++ b/grpc/handlers_notif.go
@@ -28,8 +28,8 @@ func mapToPbNotification(n domain.Notification) *pb.Notification {
 		pbinv := &pb.Invitation{
 			InvitationID:     n.ID,
 			InviterPublicKey: inv.InviterPublicKey,
-			// TODO: Status: come form shared with me thread,
-			ItemPaths: pbpths,
+			Status:           pb.InvitationStatus(inv.Status),
+			ItemPaths:        pbpths,
 		}
 		ro := &pb.Notification_InvitationValue{pbinv}
 		parsedNotif := &pb.Notification{

--- a/mocks/Model.go
+++ b/mocks/Model.go
@@ -246,6 +246,29 @@ func (_m *Model) FindReceivedFile(ctx context.Context, remoteDbID string, bucket
 	return r0, r1
 }
 
+// FindReceivedFilesByIds provides a mock function with given fields: ctx, ids
+func (_m *Model) FindReceivedFilesByIds(ctx context.Context, ids []string) ([]*model.ReceivedFileSchema, error) {
+	ret := _m.Called(ctx, ids)
+
+	var r0 []*model.ReceivedFileSchema
+	if rf, ok := ret.Get(0).(func(context.Context, []string) []*model.ReceivedFileSchema); ok {
+		r0 = rf(ctx, ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.ReceivedFileSchema)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = rf(ctx, ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListBuckets provides a mock function with given fields: ctx
 func (_m *Model) ListBuckets(ctx context.Context) ([]*model.BucketSchema, error) {
 	ret := _m.Called(ctx)


### PR DESCRIPTION
### Change Log
* Get received files by ID helper
* Make message parser handle multiple so we can keep message specific logic in there
* Add fetch of statuses for messages
* Also a couple bugs that was in the way of this working:
* Bug: notification ID was not being saved in received files
* Bug: GetThreadContext was not creating new token so if transitioning from hub to local it failed (hotfixed this for now but maybe in a future fix we can tie this back to the cached token and switch based on the passed in `threadsClient` host or something)
