### PR TITLE
Hotfix: make backup on task parallelizable

### DIFF
--- a/core/textile/sync/synchronizer.go
+++ b/core/textile/sync/synchronizer.go
@@ -123,6 +123,7 @@ func (s *synchronizer) NotifyBucketCreated(bucket string, enckey []byte) {
 
 func (s *synchronizer) NotifyBucketBackupOn(bucket string) {
 	t := newTask(bucketBackupOnTask, []string{bucket})
+	t.Parallelizable = true
 	s.enqueueTask(t, s.taskQueue)
 
 	s.notifySyncNeeded()


### PR DESCRIPTION
This will at least make other tasks complete, but until we can call `AddReplicator` against prd hub without any errors we need this.