### PR TITLE
Make iterator fn use file path instead of ipfs path

### DIFF
--- a/core/textile/bucket/bucket_dir.go
+++ b/core/textile/bucket/bucket_dir.go
@@ -133,10 +133,15 @@ func (b *Bucket) Each(ctx context.Context, path string, iterator EachFunc, withR
 			continue
 		}
 
+		currItemPath := item.Name
+		if path != "" {
+			currItemPath = path + "/" + currItemPath
+		}
+
 		var n int
 
 		if withRecursive && item.IsDir {
-			if n, err = b.Each(ctx, item.Path, iterator, withRecursive); err != nil {
+			if n, err = b.Each(ctx, currItemPath, iterator, withRecursive); err != nil {
 				return 0, err
 			}
 
@@ -144,7 +149,7 @@ func (b *Bucket) Each(ctx context.Context, path string, iterator EachFunc, withR
 			continue
 		}
 
-		if err := iterator(ctx, b, item.Path); err != nil {
+		if err := iterator(ctx, b, currItemPath); err != nil {
 			return 0, err
 		}
 

--- a/core/textile/sync/restore.go
+++ b/core/textile/sync/restore.go
@@ -25,7 +25,8 @@ func (s *synchronizer) restoreBucket(ctx context.Context, bucketSlug string) err
 
 	iterator := func(c context.Context, b *bucket.Bucket, itemPath string) error {
 		exists, err := localBucket.FileExists(c, itemPath)
-		if err != nil {
+		if err != nil && err.Error() != "rpc error: code = DeadlineExceeded desc = context deadline exceeded" {
+			// deadline exceeded can be interpreted as the file not being present
 			return err
 		}
 


### PR DESCRIPTION
# Change log

- Make the restore iterator use the actual file path instead of the ipfs path