### PR TITLE
Feature: Search Files/Folders Implementation

### DIFF
--- a/core/space/domain/domain.go
+++ b/core/space/domain/domain.go
@@ -168,3 +168,9 @@ type SharedDirEntry struct {
 	FileInfo
 	Members []Member // XXX: it is duplicated from FileInfo
 }
+
+type SearchFileEntry struct {
+	FileInfo
+	Bucket string
+	DbID   string
+}

--- a/core/space/services/services_search.go
+++ b/core/space/services/services_search.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"context"
+	"path"
+
+	"github.com/FleekHQ/space-daemon/core/textile/model"
+
+	"github.com/FleekHQ/space-daemon/core/space/domain"
+)
+
+func (s *Space) SearchFiles(ctx context.Context, query string) ([]domain.SearchFileEntry, error) {
+	searchResult, err := s.tc.GetModel().QuerySearchIndex(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	resultEntries := make([]domain.SearchFileEntry, len(searchResult))
+
+	for i, result := range searchResult {
+		resultEntries[i] = domain.SearchFileEntry{
+			FileInfo: domain.FileInfo{
+				DirEntry: domain.DirEntry{
+					Path:          result.ItemPath,
+					IsDir:         result.ItemType == string(model.DirectoryItem),
+					Name:          result.ItemName,
+					FileExtension: path.Ext(result.ItemName),
+				},
+			},
+			Bucket: result.BucketSlug,
+			DbID:   result.DbId,
+		}
+	}
+
+	return resultEntries, nil
+}

--- a/core/space/space.go
+++ b/core/space/space.go
@@ -60,6 +60,7 @@ type Service interface {
 	SetNotificationsLastSeenAt(timestamp int64) error
 	GetNotificationsLastSeenAt() (int64, error)
 	TruncateData(ctx context.Context) error
+	SearchFiles(ctx context.Context, query string) ([]domain.SearchFileEntry, error)
 }
 
 type serviceOptions struct {

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -397,6 +397,11 @@ func (tc *textileClient) initialize(ctx context.Context) error {
 		}
 	}
 
+	if err = tc.initSearchIndex(ctx); err != nil {
+		log.Error("Error initializing users search index", err)
+		return err
+	}
+
 	tc.sync.NotifyBucketStartup(defaultPersonalBucketSlug)
 
 	tc.isInitialized = true

--- a/core/textile/model/model.go
+++ b/core/textile/model/model.go
@@ -61,6 +61,15 @@ type Model interface {
 	ListReceivedPublicFiles(ctx context.Context, cidHash string, accepted bool) ([]*ReceivedFileSchema, error)
 	FindMirrorFileByPaths(ctx context.Context, paths []string) (map[string]*MirrorFileSchema, error)
 	FindReceivedFilesByIds(ctx context.Context, ids []string) ([]*ReceivedFileSchema, error)
+	InitSearchIndexCollection(ctx context.Context) error
+	UpdateSearchIndexRecord(
+		ctx context.Context,
+		name, path string,
+		itemType SearchItemType,
+		bucketSlug, dbId string,
+	) (*SearchIndexRecord, error)
+	QuerySearchIndex(ctx context.Context, query string) ([]*SearchIndexRecord, error)
+	DeleteSearchIndexRecord(ctx context.Context, name, path, bucketSlug, dbId string) error
 }
 
 func New(st store.Store, kc keychain.Keychain, threads *threadsClient.Client, ht *threadsClient.Client, hubAuth hub.HubAuth, cfg config.Config, netc *nc.Client) *model {

--- a/core/textile/model/search.go
+++ b/core/textile/model/search.go
@@ -1,0 +1,186 @@
+package model
+
+import (
+	"context"
+	"path"
+
+	"github.com/textileio/go-threads/core/thread"
+	"github.com/textileio/go-threads/util"
+
+	"github.com/pkg/errors"
+	"github.com/textileio/go-threads/db"
+
+	"github.com/FleekHQ/space-daemon/log"
+	"github.com/textileio/go-threads/api/client"
+	core "github.com/textileio/go-threads/core/db"
+)
+
+type SearchItemType string
+
+const (
+	FileItem      SearchItemType = "FILE"
+	DirectoryItem SearchItemType = "DIRECTORY"
+)
+
+type SearchIndexRecord struct {
+	ID            core.InstanceID `json:"_id"`
+	ItemName      string          `json:"itemName"`
+	ItemExtension string          `json:"itemExtension"`
+	ItemPath      string          `json:"itemPath"`
+	ItemType      string          `json:"itemType"` // currently either FILE/DIRECTORY
+	// Metadata here
+	BucketSlug string `json:"bucketSlug"`
+	DbId       string `json:"dbId"`
+}
+
+const searchIndexModelName = "SearchIndexMetadata"
+
+func (m *model) InitSearchIndexCollection(ctx context.Context) error {
+	log.Debug("Model.InitSearchIndexCollection: Initializing db")
+	_, err := m.initSearchModel(ctx)
+	return err
+}
+
+func (m *model) initSearchModel(ctx context.Context) (*thread.ID, error) {
+	metaCtx, dbId, err := m.getMetaThreadContext(ctx)
+	if err != nil || dbId == nil {
+		return nil, err
+	}
+
+	_, err = m.threads.GetCollectionInfo(metaCtx, *dbId, searchIndexModelName)
+	if err == nil {
+		// collection already exists
+		return dbId, nil
+	}
+
+	// create search collection
+	if err := m.threads.NewCollection(metaCtx, *dbId, db.CollectionConfig{
+		Name:   searchIndexModelName,
+		Schema: util.SchemaFromInstance(&SearchIndexRecord{}, false),
+		Indexes: []db.Index{
+			{
+				Path:   "itemName",
+				Unique: false,
+			},
+			{
+				Path:   "itemPath",
+				Unique: false,
+			},
+			{
+				Path:   "itemType",
+				Unique: false,
+			},
+			{
+				Path:   "itemExtension",
+				Unique: false,
+			},
+		},
+	}); err != nil {
+		log.Warn("Creating Search collection failed", "error:"+err.Error())
+		return nil, err
+	}
+
+	return dbId, nil
+}
+
+func (m *model) UpdateSearchIndexRecord(
+	ctx context.Context,
+	name, itemPath string,
+	itemType SearchItemType,
+	bucketSlug, dbId string,
+) (*SearchIndexRecord, error) {
+	log.Debug("Model.UpdateSearchIndexRecord: Initializing db")
+	metaCtx, metaDbID, err := m.initBucketModel(ctx)
+	if err != nil || metaDbID == nil {
+		return nil, err
+	}
+
+	// if record already exists avoid duplication
+	query := db.Where("itemName").Eq(name).And("itemPath").Eq(itemPath).And("bucketSlug").Eq(bucketSlug)
+	if dbId != "" {
+		query = query.And("dbId").Eq(dbId)
+	}
+	existingRecords, err := m.threads.Find(metaCtx, *metaDbID, searchIndexModelName, query, &SearchIndexRecord{})
+	if err == nil && len(existingRecords.([]*SearchIndexRecord)) > 0 {
+		return existingRecords.([]*SearchIndexRecord)[0], nil
+	}
+
+	newInstance := &SearchIndexRecord{
+		ID:            "",
+		ItemName:      name,
+		ItemExtension: path.Ext(name),
+		ItemPath:      itemPath,
+		ItemType:      string(itemType),
+		DbId:          dbId,
+		BucketSlug:    bucketSlug,
+	}
+
+	instances := client.Instances{newInstance}
+	log.Debug("Model.UpdateSearchIndexRecord: Creating instance")
+
+	res, err := m.threads.Create(metaCtx, *metaDbID, searchIndexModelName, instances)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("Model.UpdateSearchIndexRecord: Instance creation successful", "instanceId:"+newInstance.ID.String())
+
+	id := res[0]
+	return &SearchIndexRecord{
+		ID:         core.InstanceID(id),
+		ItemName:   newInstance.ItemName,
+		ItemPath:   newInstance.ItemPath,
+		ItemType:   newInstance.ItemType,
+		BucketSlug: newInstance.BucketSlug,
+		DbId:       newInstance.DbId,
+	}, nil
+}
+
+func (m *model) QuerySearchIndex(ctx context.Context, query string) ([]*SearchIndexRecord, error) {
+	metaCtx, metaDbID, err := m.initBucketModel(ctx)
+	if err != nil || metaDbID == nil {
+		return nil, err
+	}
+
+	log.Debug("Model.QuerySearchIndex: start search", "query:"+query)
+	res, err := m.threads.Find(
+		metaCtx,
+		*metaDbID,
+		searchIndexModelName,
+		db.Where("itemName").Eq(query).Or(db.Where("itemExtension").Eq(query)).LimitTo(20),
+		&SearchIndexRecord{},
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "search query failed")
+	}
+
+	return res.([]*SearchIndexRecord), nil
+}
+
+// DeleteSearchIndexRecords updates the search index by deleting records that match the name and path.
+func (m *model) DeleteSearchIndexRecord(ctx context.Context, name, path, bucketSlug, dbId string) error {
+	metaCtx, metaDbID, err := m.initBucketModel(ctx)
+	if err != nil || metaDbID == nil {
+		return err
+	}
+
+	query := db.Where("itemName").Eq(name).And("itemPath").Eq(path).And("bucketSlug").Eq(bucketSlug)
+	if dbId != "" {
+		query = query.And("dbId").Eq(dbId)
+	}
+
+	res, err := m.threads.Find(metaCtx, *metaDbID, searchIndexModelName, query, &SearchIndexRecord{})
+	if err != nil {
+		return err
+	}
+	records := res.([]*SearchIndexRecord)
+	if len(records) == 0 {
+		return nil
+	}
+
+	var instanceIds []string
+	for _, record := range records {
+		instanceIds = append(instanceIds, record.ID.String())
+	}
+
+	return m.threads.Delete(metaCtx, *metaDbID, searchIndexModelName, instanceIds)
+}

--- a/core/textile/search.go
+++ b/core/textile/search.go
@@ -1,0 +1,8 @@
+package textile
+
+import "context"
+
+func (tc *textileClient) initSearchIndex(ctx context.Context) error {
+	err := tc.GetModel().InitSearchIndexCollection(ctx)
+	return err
+}

--- a/core/textile/sharing.go
+++ b/core/textile/sharing.go
@@ -118,7 +118,7 @@ func (tc *textileClient) createReceivedFiles(
 		if accepted {
 			encryptionKeys = invitation.Keys[i]
 		}
-		_, err := tc.GetModel().CreateReceivedFileViaInvitation(ctx, path, invitation.InvitationID, accepted, encryptionKeys)
+		receivedFile, err := tc.GetModel().CreateReceivedFileViaInvitation(ctx, path, invitation.InvitationID, accepted, encryptionKeys)
 
 		// compose each create error
 		if err != nil {
@@ -126,6 +126,10 @@ func (tc *textileClient) createReceivedFiles(
 				allErr = errors.Wrap(err, "Failed to accept some invitations")
 			}
 			allErr = errors.Wrap(err, allErr.Error())
+		} else {
+			if accepted {
+				tc.sync.NotifyIndexItemAdded(receivedFile.Bucket, receivedFile.Path, receivedFile.DbID)
+			}
 		}
 	}
 

--- a/core/textile/sync/sync.go
+++ b/core/textile/sync/sync.go
@@ -19,6 +19,7 @@ type Synchronizer interface {
 	NotifyBucketRestore(bucket string)
 	NotifyFileRestore(bucket, path string)
 	NotifyBucketStartup(bucket string)
+	NotifyIndexItemAdded(bucket, path, dbId string)
 	Start(ctx context.Context)
 	RestoreQueue() error
 	Shutdown()

--- a/core/textile/sync/task.go
+++ b/core/textile/sync/task.go
@@ -16,6 +16,8 @@ const (
 	bucketBackupOffTask taskType = "TOGGLE_BACKUP_OFF"
 	bucketRestoreTask   taskType = "BUCKET_RESTORE"
 	restoreFileTask     taskType = "RESTORE_FILE"
+	addIndexItemTask    taskType = "ADD_INDEX_ITEM"
+	removeIndexItemTask taskType = "REMOVE_INDEX_ITEM"
 )
 
 type taskState string

--- a/grpc/handlers_search.go
+++ b/grpc/handlers_search.go
@@ -7,7 +7,6 @@ import (
 )
 
 // Search files based on query fields
-// NOTE: This is still a TODO the current implementation just returns a list of files in the base personal bucket
 func (srv *grpcServer) SearchFiles(ctx context.Context, request *pb.SearchFilesRequest) (*pb.SearchFilesResponse, error) {
 	if request.Query == "" {
 		return &pb.SearchFilesResponse{
@@ -16,18 +15,29 @@ func (srv *grpcServer) SearchFiles(ctx context.Context, request *pb.SearchFilesR
 		}, nil
 	}
 
-	entries, err := srv.sv.ListDir(ctx, "", "", false)
+	entries, err := srv.sv.SearchFiles(ctx, request.Query)
 	if err != nil {
 		return nil, err
 	}
 
-	dirEntries := mapFileInfoToDirectoryEntry(entries)
-	searchResponseEntries := make([]*pb.SearchFilesDirectoryEntry, len(dirEntries))
-	for i, e := range dirEntries {
+	searchResponseEntries := make([]*pb.SearchFilesDirectoryEntry, len(entries))
+	for i, e := range entries {
 		searchResponseEntries[i] = &pb.SearchFilesDirectoryEntry{
-			Entry:  e,
-			DbId:   "", // TODO: To be filled
-			Bucket: "", // TODO: To be filled
+			Entry: &pb.ListDirectoryEntry{
+				Path:                e.Path,
+				IsDir:               e.IsDir,
+				Name:                e.Name,
+				SizeInBytes:         e.SizeInBytes,
+				Created:             e.Created,
+				Updated:             e.Updated,
+				FileExtension:       e.FileExtension,
+				IpfsHash:            e.IpfsHash,
+				IsLocallyAvailable:  e.LocallyAvailable,
+				IsBackupInProgress:  e.BackupInProgress,
+				IsRestoreInProgress: e.RestoreInProgress,
+			},
+			DbId:   e.DbID,
+			Bucket: e.Bucket,
 		}
 	}
 

--- a/mocks/Model.go
+++ b/mocks/Model.go
@@ -131,13 +131,13 @@ func (_m *Model) CreateReceivedFileViaInvitation(ctx context.Context, file domai
 	return r0, r1
 }
 
-// CreateReceivedFileViaPublicLink provides a mock function with given fields: ctx, ipfsHash, fileKey, filename, filesize, accepted
-func (_m *Model) CreateReceivedFileViaPublicLink(ctx context.Context, ipfsHash string, fileKey string, filename string, filesize string, accepted bool) (*model.ReceivedFileSchema, error) {
-	ret := _m.Called(ctx, ipfsHash, fileKey, filename, filesize, accepted)
+// CreateReceivedFileViaPublicLink provides a mock function with given fields: ctx, ipfsHash, password, filename, filesize, accepted
+func (_m *Model) CreateReceivedFileViaPublicLink(ctx context.Context, ipfsHash string, password string, filename string, filesize string, accepted bool) (*model.ReceivedFileSchema, error) {
+	ret := _m.Called(ctx, ipfsHash, password, filename, filesize, accepted)
 
 	var r0 *model.ReceivedFileSchema
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, bool) *model.ReceivedFileSchema); ok {
-		r0 = rf(ctx, ipfsHash, fileKey, filename, filesize, accepted)
+		r0 = rf(ctx, ipfsHash, password, filename, filesize, accepted)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ReceivedFileSchema)
@@ -146,7 +146,7 @@ func (_m *Model) CreateReceivedFileViaPublicLink(ctx context.Context, ipfsHash s
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, bool) error); ok {
-		r1 = rf(ctx, ipfsHash, fileKey, filename, filesize, accepted)
+		r1 = rf(ctx, ipfsHash, password, filename, filesize, accepted)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -175,6 +175,20 @@ func (_m *Model) CreateSharedPublicKey(ctx context.Context, pubKey string) (*mod
 	}
 
 	return r0, r1
+}
+
+// DeleteSearchIndexRecord provides a mock function with given fields: ctx, name, path, bucketSlug, dbId
+func (_m *Model) DeleteSearchIndexRecord(ctx context.Context, name string, path string, bucketSlug string, dbId string) error {
+	ret := _m.Called(ctx, name, path, bucketSlug, dbId)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
+		r0 = rf(ctx, name, path, bucketSlug, dbId)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // FindBucket provides a mock function with given fields: ctx, bucketSlug
@@ -315,6 +329,20 @@ func (_m *Model) FindReceivedFilesByIds(ctx context.Context, ids []string) ([]*m
 	return r0, r1
 }
 
+// InitSearchIndexCollection provides a mock function with given fields: ctx
+func (_m *Model) InitSearchIndexCollection(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ListBuckets provides a mock function with given fields: ctx
 func (_m *Model) ListBuckets(ctx context.Context) ([]*model.BucketSchema, error) {
 	ret := _m.Called(ctx)
@@ -407,6 +435,29 @@ func (_m *Model) ListSharedPublicKeys(ctx context.Context) ([]*model.SharedPubli
 	return r0, r1
 }
 
+// QuerySearchIndex provides a mock function with given fields: ctx, query
+func (_m *Model) QuerySearchIndex(ctx context.Context, query string) ([]*model.SearchIndexRecord, error) {
+	ret := _m.Called(ctx, query)
+
+	var r0 []*model.SearchIndexRecord
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*model.SearchIndexRecord); ok {
+		r0 = rf(ctx, query)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.SearchIndexRecord)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, query)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateMirrorFile provides a mock function with given fields: ctx, mirrorFile
 func (_m *Model) UpdateMirrorFile(ctx context.Context, mirrorFile *model.MirrorFileSchema) (*model.MirrorFileSchema, error) {
 	ret := _m.Called(ctx, mirrorFile)
@@ -423,6 +474,29 @@ func (_m *Model) UpdateMirrorFile(ctx context.Context, mirrorFile *model.MirrorF
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *model.MirrorFileSchema) error); ok {
 		r1 = rf(ctx, mirrorFile)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateSearchIndexRecord provides a mock function with given fields: ctx, name, path, itemType, bucketSlug, dbId
+func (_m *Model) UpdateSearchIndexRecord(ctx context.Context, name string, path string, itemType model.SearchItemType, bucketSlug string, dbId string) (*model.SearchIndexRecord, error) {
+	ret := _m.Called(ctx, name, path, itemType, bucketSlug, dbId)
+
+	var r0 *model.SearchIndexRecord
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, model.SearchItemType, string, string) *model.SearchIndexRecord); ok {
+		r0 = rf(ctx, name, path, itemType, bucketSlug, dbId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.SearchIndexRecord)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, model.SearchItemType, string, string) error); ok {
+		r1 = rf(ctx, name, path, itemType, bucketSlug, dbId)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
**CHANGELOG**
- Creates a search index collection on the meta thread. The search collection is created when the daemon initialization `rpc` is called.
- Export functions to update, query, and delete items from the search index


**TODO**
- [x] Index shared files via synchronizer
