### PR TITLE
Fix a tc.sync.NotifyBucketStartup() SIGSEGV

### DIFF
--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -397,7 +397,9 @@ func (tc *textileClient) initialize(ctx context.Context) error {
 		}
 	}
 
-	tc.sync.NotifyBucketStartup(defaultPersonalBucketSlug)
+	if tc.sync != nil {
+		tc.sync.NotifyBucketStartup(defaultPersonalBucketSlug)
+	}
 
 	tc.isInitialized = true
 	// Non-blocking channel send in case there are no listeners registered


### PR DESCRIPTION
```
goroutine 9970 [running]:
github.com/FleekHQ/space-daemon/core/textile.(*textileClient).initialize(0xc009d987e0, 0x6ab8720, 0xc000562400, 0x0, 0x0)
    /Users/maurycy/src/space-daemon/core/textile/client.go:400 +0x150
github.com/FleekHQ/space-daemon/core/textile.(*textileClient).healthcheck(0xc009d987e0, 0x6ab8720, 0xc000562400)
    /Users/maurycy/src/space-daemon/core/textile/client.go:474 +0x2e0
github.com/FleekHQ/space-daemon/core/textile.(*textileClient).start(0xc009d987e0, 0x6ab8720, 0xc000562400, 0x6aac8e0, 0xc000194b80, 0x5caf100, 0x5f98680)
    /Users/maurycy/src/space-daemon/core/textile/client.go:232 +0x59e
github.com/FleekHQ/space-daemon/core/textile.(*textileClient).Start(...)
    /Users/maurycy/src/space-daemon/core/textile/client.go:418
github.com/FleekHQ/space-daemon/app.(*App).Start.func3(0xc0068f4fa8, 0x49d2fb3)
    /Users/maurycy/src/space-daemon/app/app.go:126 +0x52
github.com/FleekHQ/space-daemon/app.(*App).RunAsync.func1(0xc0068f4fb0, 0x4042a16)
    /Users/maurycy/src/space-daemon/app/app.go:236 +0x2f
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000732510, 0xc009da88a0)
    /Users/maurycy/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
    /Users/maurycy/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:54 +0x66
```