### PR TITLE
Fix: Search Index Extension and Result Path trimming

### DIFF
--- a/core/space/services/services_search.go
+++ b/core/space/services/services_search.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
-	"path"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/FleekHQ/space-daemon/core/textile/model"
 
@@ -21,10 +23,10 @@ func (s *Space) SearchFiles(ctx context.Context, query string) ([]domain.SearchF
 		resultEntries[i] = domain.SearchFileEntry{
 			FileInfo: domain.FileInfo{
 				DirEntry: domain.DirEntry{
-					Path:          result.ItemPath,
+					Path:          strings.TrimPrefix(result.ItemPath, fmt.Sprintf("%c", os.PathSeparator)),
 					IsDir:         result.ItemType == string(model.DirectoryItem),
 					Name:          result.ItemName,
-					FileExtension: path.Ext(result.ItemName),
+					FileExtension: result.ItemExtension,
 				},
 			},
 			Bucket: result.BucketSlug,

--- a/core/textile/model/search.go
+++ b/core/textile/model/search.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"path"
+	"strings"
 
 	"github.com/textileio/go-threads/core/thread"
 	"github.com/textileio/go-threads/util"
@@ -108,7 +109,7 @@ func (m *model) UpdateSearchIndexRecord(
 	newInstance := &SearchIndexRecord{
 		ID:            "",
 		ItemName:      name,
-		ItemExtension: path.Ext(name),
+		ItemExtension: strings.Replace(path.Ext(name), ".", "", -1),
 		ItemPath:      itemPath,
 		ItemType:      string(itemType),
 		DbId:          dbId,


### PR DESCRIPTION
**CHANGELOG**
- Fixes file extension indexing `.` with extensions.
- Trim's prefix path separators returns with search path results.