### PR TITLE
Hotfix: opening file inside a subfolder instead of root

### DIFF
--- a/core/textile/secure_bucket_client.go
+++ b/core/textile/secure_bucket_client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -116,7 +117,8 @@ func (s *SecureBucketClient) PullPath(ctx context.Context, key, path string, wri
 		return err
 	}
 
-	encryptedPath, _, err := s.encryptPathData(ctx, encryptionKey, path, nil)
+	_, filename := filepath.Split(path)
+	encryptedPath, _, err := s.encryptPathData(ctx, encryptionKey, filename, nil)
 	if err != nil {
 		return err
 	}
@@ -288,6 +290,7 @@ func (s *SecureBucketClient) racePullFile(ctx context.Context, key, encPath stri
 
 	for _, fn := range pullers {
 		f, err := ioutil.TempFile("", "*-"+encPath)
+
 		if err != nil {
 			cancelPulls()
 			return err


### PR DESCRIPTION
For some reason `ioutil.TempFile` didn't like the encrypted file path here. Possible due to slashes/weird characters getting in the way. The fix just calculates a sha256 of the encrypted file name so it is somewhat normalized as far as characters go but still unique.