### PR TITLE
sqlite: use usr.HomeDir

### DIFF
--- a/config/map_config.go
+++ b/config/map_config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+	"os/user"
+	"path/filepath"
 
 	"github.com/FleekHQ/space-daemon/core/env"
 )
@@ -17,8 +19,10 @@ func NewMap(envVal env.SpaceEnv, flags *Flags) Config {
 	configInt := make(map[string]int)
 	configBool := make(map[string]bool)
 
+	usr, _ := user.Current()
+
 	// default values
-	configStr[SpaceStorePath] = "~/.fleek-space"
+	configStr[SpaceStorePath] = filepath.Join(usr.HomeDir, ".fleek-space")
 	configStr[MountFuseDrive] = "false"
 	configStr[FuseDriveName] = "Space"
 	configInt[SpaceServerPort] = 9999

--- a/core/search/sqlite/sqlite.go
+++ b/core/search/sqlite/sqlite.go
@@ -51,6 +51,7 @@ func NewSearchEngine(opts ...Option) *sqliteFilesSearchEngine {
 
 func (s *sqliteFilesSearchEngine) Start() error {
 	dsn := filepath.Join(s.opts.dbPath, DbFileName)
+
 	if db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(s.opts.logLevel),
 	}); err != nil {

--- a/core/search/sqlite/sqlite.go
+++ b/core/search/sqlite/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/user"
 	"strconv"
 	"strings"
 
@@ -49,6 +50,14 @@ func NewSearchEngine(opts ...Option) *sqliteFilesSearchEngine {
 
 func (s *sqliteFilesSearchEngine) Start() error {
 	dsn := fmt.Sprintf("%s%c%s", s.opts.dbPath, os.PathSeparator, DbFileName)
+
+	usr, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	dsn = strings.Replace(dsn, "~", usr.HomeDir, -1)
+
 	if db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(s.opts.logLevel),
 	}); err != nil {

--- a/core/search/sqlite/sqlite.go
+++ b/core/search/sqlite/sqlite.go
@@ -2,9 +2,8 @@ package sqlite
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -34,8 +33,10 @@ type sqliteFilesSearchEngine struct {
 
 // Creates a new SQLite backed search engine for files and folders
 func NewSearchEngine(opts ...Option) *sqliteFilesSearchEngine {
+	usr, _ := user.Current()
+
 	searchOptions := sqliteSearchOption{
-		dbPath: fmt.Sprintf("~%c.fleek-space", os.PathSeparator),
+		dbPath: filepath.Join(usr.HomeDir, ".fleek-space"),
 	}
 
 	for _, opt := range opts {
@@ -49,15 +50,7 @@ func NewSearchEngine(opts ...Option) *sqliteFilesSearchEngine {
 }
 
 func (s *sqliteFilesSearchEngine) Start() error {
-	dsn := fmt.Sprintf("%s%c%s", s.opts.dbPath, os.PathSeparator, DbFileName)
-
-	usr, err := user.Current()
-	if err != nil {
-		return err
-	}
-
-	dsn = strings.Replace(dsn, "~", usr.HomeDir, -1)
-
+	dsn := filepath.Join(s.opts.dbPath, DbFileName)
 	if db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(s.opts.logLevel),
 	}); err != nil {


### PR DESCRIPTION
The pull request fixes the following error:

```
ERRO[0169] Error initializing files search index -- ERROR -- failed to open database: unable to open database file: no such file or directory[]
```

The tilde is replaced in `Start()` instead of `NewSearchEngine()` because the latter returns only `*sqliteFilesSearchEngine`, without the `err`, and the former is called only once anyway.