### PR TITLE
Fix: Close Temp File after open for info

### DIFF
--- a/core/space/services/services_fs.go
+++ b/core/space/services/services_fs.go
@@ -362,6 +362,7 @@ func (s *Space) openFileOnFs(ctx context.Context, path string, b textile.Bucket,
 		log.Error("cannot create temp file while executing OpenFile", err)
 		return "", err
 	}
+	defer tmpFile.Close()
 
 	// look for path in textile
 	err = b.GetFile(ctx, path, tmpFile)


### PR DESCRIPTION
**CHANGELOG**
- When getting a reference to a temp file on the OpenFile() rpc call, the reference is no closed (leaks) and causes windows to prevent editing the file.