### PR TITLE
Fix: Speed up public link generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,12 @@ gen_rest_swagger:
 		&& statik -src=swagger/ui -f -dest=swagger -p=bin_ui
 
 gen_all: proto_gen gen_rest gen_rest_swagger
+
+## runs jaeger tracing server, should be used when trace is enabled on daemon
+jaegar:
+	docker run \
+		--rm \
+		--name jaeger \
+		-p 6831:6831/udp \
+		-p 16686:16686 \
+		jaegertracing/all-in-one:latest

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ ensure everything is up to date **
 NOTE: See here for instructions on Reverse Proxy:
 https://github.com/grpc-ecosystem/grpc-gateway
 
-### Debugging and Profiling
+### Debugging, Profiling and Tracing
 
 The following flags can be run with the binary to output profiling files for debugging.
 Flags support a full path to a file.
@@ -186,6 +186,10 @@ server in localhost:6060. See docs how to interact with pprof server here: https
 
 To disable debug mode add this flag to binary arguments
 `-debug=false`
+
+To enable trace in the daemon, pass `-trace` to the binary arguments. The daemon uses [jaegar](https://www.jaegertracing.io/) 
+for collecting trace information. Run `make jaegar` to quickly start a jaeger agent that collects the daemons trace information.
+You can `http://localhost:16686/` to explore the web ui for traces collected.
 
 ### CI Secrets
 

--- a/core/space/services/services_sharing.go
+++ b/core/space/services/services_sharing.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/FleekHQ/space-daemon/config"
 
 	"github.com/FleekHQ/space-daemon/log"
@@ -32,6 +34,9 @@ func (s *Space) GenerateFileSharingLink(
 	bucketName string,
 	dbID string,
 ) (domain.FileSharingInfo, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Space.GenerateFileSharingLink")
+	defer span.Finish()
+
 	_, fileName := filepath.Split(path)
 
 	var bucket t.Bucket
@@ -46,38 +51,7 @@ func (s *Space) GenerateFileSharingLink(
 		return domain.FileSharingInfo{}, err
 	}
 
-	// tempFile is written from textile before encryption
-	tempFile, err := s.createTempFileForPath(ctx, path, true)
-	if err != nil {
-		return domain.FileSharingInfo{}, err
-	}
-	defer func() {
-		tempFile.Close()
-		_ = os.Remove(tempFile.Name())
-	}()
-
-	// encrypted file is the final encrypted file
-	encryptedFile, err := s.createTempFileForPath(ctx, path, true)
-	if err != nil {
-		return domain.FileSharingInfo{}, err
-	}
-	defer encryptedFile.Close()
-
-	err = bucket.GetFile(ctx, path, tempFile)
-	if err != nil {
-		return EmptyFileSharingInfo, errors.Wrap(err, "file encryption failed")
-	}
-	_, err = tempFile.Seek(0, 0)
-	if err != nil {
-		return EmptyFileSharingInfo, errors.Wrap(err, "file encryption failed")
-	}
-	encryptedReader, err := dcrypto.NewEncrypterWithPassword(tempFile, []byte(encryptionPassword))
-	if err != nil {
-		return EmptyFileSharingInfo, errors.Wrap(err, "file encryption failed")
-	}
-
-	log.Printf("Copying encrypted file to disk")
-	_, err = io.Copy(encryptedFile, encryptedReader)
+	encryptedFile, err := s.encryptBucketFile(ctx, encryptionPassword, path, bucket)
 	if err != nil {
 		return EmptyFileSharingInfo, errors.Wrap(err, "file encryption failed")
 	}
@@ -98,6 +72,49 @@ func (s *Space) GenerateFileSharingLink(
 	)
 }
 
+func (s *Space) encryptBucketFile(
+	ctx context.Context,
+	password string,
+	bucketPath string,
+	bucket t.Bucket,
+) (*os.File, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Space.encryptBucketFile")
+	defer span.Finish()
+
+	// tempFile is written from textile before encryption
+	tempFile, err := s.createTempFileForPath(ctx, bucketPath, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		tempFile.Close()
+		_ = os.Remove(tempFile.Name())
+	}()
+
+	// encrypted file is the final encrypted file
+	encryptedFile, err := s.createTempFileForPath(ctx, bucketPath, true)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bucket.GetFile(ctx, bucketPath, tempFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "file encryption failed")
+	}
+	_, err = tempFile.Seek(0, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "file encryption failed")
+	}
+	encryptedReader, err := dcrypto.NewEncrypterWithPassword(tempFile, []byte(password))
+	if err != nil {
+		return nil, errors.Wrap(err, "file encryption failed")
+	}
+
+	log.Printf("Copying encrypted file to disk")
+	_, err = io.Copy(encryptedFile, encryptedReader)
+	return encryptedFile, err
+}
+
 // uploads the shared file to ipfs through users public bucket in hub
 func (s *Space) uploadSharedFileToIpfs(
 	ctx context.Context,
@@ -106,6 +123,9 @@ func (s *Space) uploadSharedFileToIpfs(
 	fileName string,
 	bucketName string,
 ) (domain.FileSharingInfo, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Space.uploadSharedFileToIpfs")
+	defer span.Finish()
+
 	b, err := s.tc.GetPublicShareBucket(ctx)
 	if err != nil {
 		return EmptyFileSharingInfo, errors.Wrap(err, "failed to get public files bucket")
@@ -136,7 +156,15 @@ func (s *Space) uploadSharedFileToIpfs(
 }
 
 // GenerateFilesSharingLink zips multiple files together
-func (s *Space) GenerateFilesSharingLink(ctx context.Context, encryptionPassword string, paths []string, bucketName, dbID string) (domain.FileSharingInfo, error) {
+func (s *Space) GenerateFilesSharingLink(
+	ctx context.Context,
+	encryptionPassword string,
+	paths []string,
+	bucketName, dbID string,
+) (domain.FileSharingInfo, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Space.GenerateFilesSharingLink")
+	defer span.Finish()
+
 	if len(paths) == 0 {
 		return EmptyFileSharingInfo, errors.New("no file passed to share link")
 	}

--- a/core/space/services/services_sharing.go
+++ b/core/space/services/services_sharing.go
@@ -56,13 +56,12 @@ func (s *Space) GenerateFileSharingLink(
 		return EmptyFileSharingInfo, errors.Wrap(err, "file encryption failed")
 	}
 
-	log.Printf("Copy successful")
 	_, err = encryptedFile.Seek(0, 0)
 	if err != nil {
 		return EmptyFileSharingInfo, errors.Wrap(err, "file encryption failed")
 	}
 
-	log.Printf("Uploading shared file")
+	log.Debug("Uploading shared file")
 	return s.uploadSharedFileToIpfs(
 		ctx,
 		encryptionPassword,
@@ -110,7 +109,7 @@ func (s *Space) encryptBucketFile(
 		return nil, errors.Wrap(err, "file encryption failed")
 	}
 
-	log.Printf("Copying encrypted file to disk")
+	log.Debug("Copying encrypted file to disk")
 	_, err = io.Copy(encryptedFile, encryptedReader)
 	return encryptedFile, err
 }

--- a/core/textile/bucket/bucket_file.go
+++ b/core/textile/bucket/bucket_file.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/FleekHQ/space-daemon/log"
 	"github.com/ipfs/interface-go-ipfs-core/path"
 )
@@ -58,7 +60,14 @@ func (b *Bucket) UpdatedAt(ctx context.Context, pth string) (int64, error) {
 	return response.Item.Metadata.UpdatedAt, nil
 }
 
-func (b *Bucket) UploadFile(ctx context.Context, path string, reader io.Reader) (result path.Resolved, root path.Path, err error) {
+func (b *Bucket) UploadFile(
+	ctx context.Context,
+	path string,
+	reader io.Reader,
+) (result path.Resolved, root path.Path, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Bucket.UploadFile")
+	defer span.Finish()
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
 

--- a/core/textile/client.go
+++ b/core/textile/client.go
@@ -421,6 +421,11 @@ func (tc *textileClient) initialize(ctx context.Context) error {
 		tc.sync.NotifyBucketStartup(defaultPersonalBucketSlug)
 	}
 
+	_, err = tc.createDefaultPublicBucket(ctx)
+	if err != nil {
+		log.Warn("Failed to create default public bucket", "err:"+err.Error())
+	}
+
 	tc.isInitialized = true
 	// Non-blocking channel send in case there are no listeners registered
 	select {

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/odeke-em/go-utils v0.0.0-20170224015737-e8ebaed0777a
 	github.com/odeke-em/go-uuid v0.0.0-20151221120446-b211d769a9aa // indirect
+	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/radovskyb/watcher v1.0.7
 	github.com/rakyll/statik v0.1.7
@@ -63,6 +64,7 @@ require (
 	github.com/textileio/textile v1.0.14 // indirect
 	github.com/textileio/textile/v2 v2.1.0
 	github.com/tyler-smith/go-bip39 v1.0.2
+	github.com/uber/jaeger-client-go v2.23.1+incompatible
 	go.etcd.io/etcd v3.3.22+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIA
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
+contrib.go.opencensus.io/exporter/jaeger v0.1.0 h1:WNc9HbA38xEQmsI40Tjd/MNU/g8byN2Of7lwIjv0Jdc=
 contrib.go.opencensus.io/exporter/jaeger v0.1.0/go.mod h1:VYianECmuFPwU37O699Vc1GOcy+y8kOsfaxHRImmjbA=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 contrib.go.opencensus.io/exporter/prometheus v0.2.0/go.mod h1:TYmVAyE8Tn1lyPcltF5IYYfWp2KHu7lQGIZnj8iZMys=
@@ -105,6 +106,7 @@ github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5/go.mod h
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -2086,8 +2088,10 @@ github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9
 github.com/tyler-smith/go-bip39 v1.0.2 h1:+t3w+KwLXO6154GNJY+qUtIxLTmFjfUmpguQT1OlOT8=
 github.com/tyler-smith/go-bip39 v1.0.2/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-client-go v2.23.1+incompatible h1:uArBYHQR0HqLFFAypI7RsWTzPSj/bDpmZZuQjMLSg1A=
 github.com/uber/jaeger-client-go v2.23.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v1.5.1-0.20181102163054-1fc5c315e03c/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
@@ -2576,6 +2580,7 @@ google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
+google.golang.org/api v0.25.0 h1:LodzhlzZEUfhXzNUMIfVlf9Gr6Ua5MMtoFWh7+f47qA=
 google.golang.org/api v0.25.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/grpc/handlers_sharing.go
+++ b/grpc/handlers_sharing.go
@@ -8,6 +8,7 @@ import (
 	"github.com/FleekHQ/space-daemon/core/util/address"
 	"github.com/FleekHQ/space-daemon/grpc/pb"
 	crypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/opentracing/opentracing-go"
 )
 
 func (srv *grpcServer) ShareFilesViaPublicKey(ctx context.Context, request *pb.ShareFilesViaPublicKeyRequest) (*pb.ShareFilesViaPublicKeyResponse, error) {
@@ -104,6 +105,9 @@ func (srv *grpcServer) GetSharedWithMeFiles(ctx context.Context, request *pb.Get
 }
 
 func (srv *grpcServer) GeneratePublicFileLink(ctx context.Context, request *pb.GeneratePublicFileLinkRequest) (*pb.GeneratePublicFileLinkResponse, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GeneratePublicFileLink")
+	defer span.Finish()
+
 	res, err := srv.sv.GenerateFilesSharingLink(ctx, request.Password, request.ItemPaths, request.Bucket, request.DbId)
 	if err != nil {
 		return nil, err

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,29 @@
+package tracing
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/uber/jaeger-client-go/config"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+// Initializes a tracer configuring the servicename as the app name
+func MustInit(appName string) (opentracing.Tracer, io.Closer) {
+	cfg := &config.Configuration{
+		ServiceName: appName,
+		Sampler: &config.SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+		Reporter: &config.ReporterConfig{
+			LogSpans: true,
+		},
+	}
+	tracer, closer, err := cfg.NewTracer()
+	if err != nil {
+		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
+	}
+	return tracer, closer
+}


### PR DESCRIPTION
**CHANGELOG**
- Setup tracing with jaegar and collect trace information on the `GeneratePublicFileLink` rpc
- Create default public share bucket on textile client initialization to prevent initialization during first time of sharing (should at least speed up some)

**Details of issue**
Uploads are still slow and tracing (see image below) shows that it take a long time while uploading to the bucket. The example in the image was a 3.5MB file and it took ~7mins to upload.
 - It looks like uploads on the hub are actually quite slow (and I don't think it is only public bucket).

![Screenshot 2020-11-11 at 13 27 52](https://user-images.githubusercontent.com/3120013/98812598-12098080-2423-11eb-8b70-7c1c0fabbef5.png)
