### PR TITLE
use a temporary directory for opening files

### DIFF
--- a/core/space/services/services_fs.go
+++ b/core/space/services/services_fs.go
@@ -358,7 +358,7 @@ func (s *Space) TruncateData(ctx context.Context) error {
 
 func (s *Space) openFileOnFs(ctx context.Context, path string, b textile.Bucket, isRemote bool, dbID, cid string) (string, error) {
 	// write file copy to temp folder
-	tmpFile, err := s.createTempFileForPath(ctx, path, false)
+	tmpFile, err := s.createTempFileForPath(ctx, path, true)
 	if err != nil {
 		log.Error("cannot create temp file while executing OpenFile", err)
 		return "", err

--- a/core/space/space_test.go
+++ b/core/space/space_test.go
@@ -328,14 +328,6 @@ func TestService_OpenFile(t *testing.T) {
 	testFileName := "file.txt"
 
 	// setup mocks
-	cfg.On("GetInt", mock.Anything, mock.Anything).Return(
-		-1,
-	)
-
-	cfg.On("GetString", mock.Anything, mock.Anything).Return(
-		"",
-	)
-
 	mockEnv.On("WorkingFolder").Return(
 		getDir().dir,
 	)
@@ -392,7 +384,7 @@ func TestService_OpenFile(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, res)
 	assert.FileExists(t, res.Location)
-	assert.Contains(t, res.Location, getDir().dir)
+	assert.Contains(t, res.Location, os.TempDir())
 	assert.True(t, strings.HasSuffix(res.Location, testFileName))
 	// assert mocks
 	cfg.AssertExpectations(t)


### PR DESCRIPTION
This pull request fixes the issue caused by Snap mounting the app in a read-only filesystem:

```
time="2020-11-20t11:53:03-05:00" level=error msg="cannot create temp file while executing openfile -- error -- open /tmp/.mount_space-clg6kd/resources/329259853-space.png: read-only file system[]"
OPEN_ERROR_EVENT {
  code: 2,
  message: 'open /tmp/.mount_space-Clg6KD/resources/329259853-space.png: read-only file system',
  metadata: {
    'access-control-expose-headers': 'Grpc-Status, Grpc-Message, Date, Vary, Content-Type, grpc-status, grpc-message',
    'content-type': 'application/grpc-web-text',
    'grpc-message': 'open /tmp/.mount_space-Clg6KD/resources/329259853-space.png: read-only file system',
    'grpc-status': '2',
    vary: 'Origin',
    connection: 'close',
    'transfer-encoding': 'chunked'
  }
}
```