### PR TITLE
windows batch script: reset space daemon env

### DIFF
--- a/scripts/windows.bat
+++ b/scripts/windows.bat
@@ -1,0 +1,11 @@
+@ECHO off
+
+REM Delete credentials associated with space daemon
+FOR /F "tokens=2" %%c IN ('@CMDKEY /list ^| @FINDSTR space:space') DO (@CMDKEY /delete:%%c)
+
+REM Delete folders created by space daemon
+@RD /S /Q "C:\\Users\\%USERNAME%\\.fleek-ipfs"
+@RD /S /Q "C:\\Users\\%USERNAME%\\.fleek-space"
+@RD /S /Q "C:\\Users\\%USERNAME%\\.buckd"
+
+@ECHO Removed credentials and deleted space daemon associated folders successfully.


### PR DESCRIPTION
Deletes space daemon credentials from the Windows credential Manager and deletes **.fleek-ipfs**, **.fleek-space** and **.buckd** folders